### PR TITLE
Avoid PG exception handling - unique constraint

### DIFF
--- a/bindings/java/src/org/sleuthkit/datamodel/HostAddressManager.java
+++ b/bindings/java/src/org/sleuthkit/datamodel/HostAddressManager.java
@@ -220,7 +220,17 @@ public class HostAddressManager {
 
 			long objId = db.addObject(parentObjId, objTypeId, connection);
 
-			String hostAddressInsertSQL = "INSERT INTO tsk_host_addresses(id, address_type, address) VALUES (?, ?, ?)"; // NON-NLS
+			/*
+			 * A conflict clause is used improve performance related to 
+			 * exception handling in the database.  
+			 */
+			String hostAddressInsertSQL;
+			if (db.getDatabaseType() == TskData.DbType.POSTGRESQL) {
+				hostAddressInsertSQL = "INSERT INTO tsk_host_addresses(id, address_type, address) VALUES (?, ?, ?) ON CONFLICT DO NOTHING"; //NON-NLS
+			} else {
+				hostAddressInsertSQL = "INSERT OR IGNORE INTO tsk_host_addresses(id, address_type, address) VALUES (?, ?, ?)"; //NON-NLS
+			}
+			
 			PreparedStatement preparedStatement = connection.getPreparedStatement(hostAddressInsertSQL, Statement.RETURN_GENERATED_KEYS);
 
 			preparedStatement.clearParameters();


### PR DESCRIPTION
The design of tsk_host_addresses table accounts for unique constraints on tsk_host_addresses_address_type_address_key

Insert attempts to this table does not need to trigger an exception processing flow in the pg db layer. It can be ignored safely. Adding ON CONFLICT DO NOTHING pattern for improved performance.