### PR TITLE
Bug fix: Older code relied on the exception

### DIFF
--- a/bindings/java/src/org/sleuthkit/datamodel/HostAddressManager.java
+++ b/bindings/java/src/org/sleuthkit/datamodel/HostAddressManager.java
@@ -212,6 +212,11 @@ public class HostAddressManager {
 		}
 		
 		String normalizedAddress = getNormalizedAddress(address);
+		// This prevents orphaned objects and ensures we return the existing valid object.
+		Optional<HostAddress> existingAddr = getHostAddress(addressType, normalizedAddress, connection);
+		if (existingAddr.isPresent()) {
+			return existingAddr.get();
+		}
 		try {
 
 			// TODO: need to get the correct parent obj id.  
@@ -220,17 +225,8 @@ public class HostAddressManager {
 
 			long objId = db.addObject(parentObjId, objTypeId, connection);
 
-			/*
-			 * A conflict clause is used improve performance related to 
-			 * exception handling in the database.  
-			 */
-			String hostAddressInsertSQL;
-			if (db.getDatabaseType() == TskData.DbType.POSTGRESQL) {
-				hostAddressInsertSQL = "INSERT INTO tsk_host_addresses(id, address_type, address) VALUES (?, ?, ?) ON CONFLICT DO NOTHING"; //NON-NLS
-			} else {
-				hostAddressInsertSQL = "INSERT OR IGNORE INTO tsk_host_addresses(id, address_type, address) VALUES (?, ?, ?)"; //NON-NLS
-			}
-			
+			String hostAddressInsertSQL = "INSERT INTO tsk_host_addresses(id, address_type, address) VALUES (?, ?, ?) "; //NON-NLS
+				
 			PreparedStatement preparedStatement = connection.getPreparedStatement(hostAddressInsertSQL, Statement.RETURN_GENERATED_KEYS);
 
 			preparedStatement.clearParameters();


### PR DESCRIPTION
Instead of a check then act pattern, the Object Id entry was made first and on insert failure the code fetched the existing record. this is not efficient as there is a database cost for raising exceptions on a function that is "hot"