### PR TITLE
Migrate raw pointers to unique_ptr and fix memory/stability issues

### DIFF
--- a/rejistry++/msvcpp/Rejistry/Rejistry.vcxproj
+++ b/rejistry++/msvcpp/Rejistry/Rejistry.vcxproj
@@ -135,6 +135,7 @@
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <AdditionalDependencies>rejistry++.lib;$(TSK_HOME)\win32\$(Configuration)\libtsk.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <AdditionalLibraryDirectories>$(SolutionDir)\$(ConfigurationName);%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <StackReserveSize>4194304</StackReserveSize>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
@@ -146,6 +147,7 @@
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <AdditionalDependencies>rejistry++.lib;$(TSK_HOME)\win32\x64\$(Configuration)\libtsk.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <AdditionalLibraryDirectories>$(SolutionDir)\$(Platform)\$(ConfigurationName);%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <StackReserveSize>4194304</StackReserveSize>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
@@ -161,6 +163,7 @@
       <OptimizeReferences>true</OptimizeReferences>
       <AdditionalDependencies>rejistry++.lib;$(TSK_HOME)\win32\$(Configuration)\libtsk.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <AdditionalLibraryDirectories>$(SolutionDir)\$(ConfigurationName);%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <StackReserveSize>4194304</StackReserveSize>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release_NoLibs|Win32'">
@@ -177,6 +180,7 @@
       <OptimizeReferences>true</OptimizeReferences>
       <AdditionalDependencies>rejistry++.lib;$(TSK_HOME)\win32\$(Configuration)\libtsk.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <AdditionalLibraryDirectories>$(SolutionDir)\$(ConfigurationName);%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <StackReserveSize>4194304</StackReserveSize>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release_XPNoLibs|Win32'">
@@ -194,6 +198,7 @@
       <AdditionalDependencies>rejistry++.lib;$(TSK_HOME)\win32\$(Configuration)\libtsk.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <AdditionalLibraryDirectories>$(SolutionDir)\$(ConfigurationName);%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
       <LinkTimeCodeGeneration>Default</LinkTimeCodeGeneration>
+      <StackReserveSize>4194304</StackReserveSize>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
@@ -209,6 +214,7 @@
       <OptimizeReferences>true</OptimizeReferences>
       <AdditionalDependencies>rejistry++.lib;$(TSK_HOME)\win32\x64\$(Configuration)\libtsk.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <AdditionalLibraryDirectories>$(SolutionDir)\$(Platform)\$(ConfigurationName);%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <StackReserveSize>4194304</StackReserveSize>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release_NoLibs|x64'">
@@ -224,6 +230,7 @@
       <OptimizeReferences>true</OptimizeReferences>
       <AdditionalDependencies>rejistry++.lib;$(TSK_HOME)\win32\x64\$(Configuration)\libtsk.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <AdditionalLibraryDirectories>$(SolutionDir)\$(Platform)\$(ConfigurationName);%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <StackReserveSize>4194304</StackReserveSize>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release_XPNoLibs|x64'">
@@ -239,6 +246,7 @@
       <OptimizeReferences>true</OptimizeReferences>
       <AdditionalDependencies>rejistry++.lib;$(TSK_HOME)\win32\x64\$(Configuration)\libtsk.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <AdditionalLibraryDirectories>$(SolutionDir)\$(Platform)\$(ConfigurationName);%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <StackReserveSize>4194304</StackReserveSize>
     </Link>
   </ItemDefinitionGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />

--- a/rejistry++/src/BinaryBlock.h
+++ b/rejistry++/src/BinaryBlock.h
@@ -45,6 +45,8 @@ namespace Rejistry {
             _offset = offset;
         }
 
+        virtual ~BinaryBlock() {}
+
     private:
 
     protected:

--- a/rejistry++/src/Buffer.h
+++ b/rejistry++/src/Buffer.h
@@ -47,7 +47,7 @@ namespace Rejistry {
         Buffer() {}
         Buffer(const uint32_t capacity);
         Buffer(const Buffer& );
-        Buffer& operator=(const Buffer& );
+        Buffer& operator=(const Buffer& ) = delete;
 
         virtual ~Buffer();
 

--- a/rejistry++/src/ByteBuffer.h
+++ b/rejistry++/src/ByteBuffer.h
@@ -78,10 +78,10 @@ namespace Rejistry {
 
         /// read at specified offset
         template <typename T> T read(uint32_t offset) const {
-            if (offset + sizeof(T) <= _limit) {
+            if ((uint64_t)offset + sizeof(T) <= (uint64_t)_limit) {
                 return *((T*)&_buffer[offset]);
             }
-            return NULL;
+            return (T)0;
         }
     };
 };

--- a/rejistry++/src/Cell.cpp
+++ b/rejistry++/src/Cell.cpp
@@ -64,12 +64,12 @@ namespace Rejistry {
         return getQWord(DATA_OFFSET);
     }
 
-    NKRecord::NKRecordPtr Cell::getNKRecord() const {
-        return new NKRecord(_buf, getAbsoluteOffset(DATA_OFFSET));
+    std::unique_ptr<NKRecord> Cell::getNKRecord() const {
+        return std::make_unique<NKRecord>(_buf, getAbsoluteOffset(DATA_OFFSET));
     }
 
-    VKRecord::VKRecordPtr Cell::getVKRecord() const {
-        return new VKRecord(_buf, getAbsoluteOffset(DATA_OFFSET));
+    std::unique_ptr<VKRecord> Cell::getVKRecord() const {
+        return std::make_unique<VKRecord>(_buf, getAbsoluteOffset(DATA_OFFSET));
     }
 
     SubkeyListRecord::SubkeyListRecordPtr Cell::getLFRecord() const {

--- a/rejistry++/src/Cell.h
+++ b/rejistry++/src/Cell.h
@@ -50,43 +50,8 @@ namespace Rejistry {
      */
     class Cell : public BinaryBlock {
     public:
-        typedef Cell * CellPtr;
-        typedef std::vector< CellPtr > CellPtrList;
-
-        /**
-            The AutoCellPtrList class should be used by clients to hold lists of
-            Cell pointers returned by methods like HBIN::getCells()
-            so that the record objects will be automatically freed. Example:
-            @code
-            AutoCellPtrList cellList(hbin->getCells());
-            for (Cell::CellPtrList::iterator i = cellList.begin(); i != cellList.end(); ++i)
-            { ... //do stuff }
-            // Don't worry about delete'ing each record object--valueList will take care of
-            // that when it goes out of scope.
-            @endcode
-        */
-        class AutoCellPtrList
-        {
-        public:
-
-            AutoCellPtrList(CellPtrList recordList) : _recordList(recordList) {}
-            ~AutoCellPtrList()
-            {
-                for (CellPtrList::iterator it = _recordList.begin(); it != _recordList.end(); ++it)
-                {
-                    delete *it;
-                }
-            }
-            CellPtrList::iterator begin() { return _recordList.begin(); }
-            CellPtrList::iterator end()   { return _recordList.end(); }
-            CellPtrList::size_type size() { return _recordList.size(); }
-        private:
-            AutoCellPtrList(const AutoCellPtrList&);
-            AutoCellPtrList& operator=(const AutoCellPtrList&);
-
-            CellPtrList _recordList;
-        };
-
+        typedef std::unique_ptr <Cell> CellUniqPtr;
+        typedef std::vector<CellUniqPtr> CellUniqPtrList;
 
         Cell(RegistryByteBuffer * buf, const uint32_t offset) : BinaryBlock(*buf, offset) {} 
         
@@ -126,17 +91,17 @@ namespace Rejistry {
 
         /**
          * Interprets the cell data as an NKRecord and returns it.
-         * @returns Pointer to an NKRecord object. Caller is responsible for freeing.
+         * @returns Unique pointer to an NKRecord object.
          * @throws RegistryParseException
          */
-        NKRecord::NKRecordPtr getNKRecord() const;
+        std::unique_ptr<NKRecord> getNKRecord() const;
 
         /**
          * Interprets the cell data as an VKRecord and returns it.
-         * @returns Pointer to an VKRecord object. (Caller must free using delete)
+         * @returns Unique pointer to an VKRecord object.
          * @throws RegistryParseException
          */
-        VKRecord::VKRecordPtr getVKRecord() const;
+        std::unique_ptr<VKRecord> getVKRecord() const;
 
         /**
          * Interprets the cell data as an LFRecord and returns it.

--- a/rejistry++/src/DBIndirectRecord.cpp
+++ b/rejistry++/src/DBIndirectRecord.cpp
@@ -45,7 +45,7 @@ namespace Rejistry {
             uint32_t size = std::min(DB_DATA_SIZE, length);
             uint32_t offset = getDWord(OFFSET_LIST_OFFSET + (count * 4));
             offset += REGFHeader::FIRST_HBIN_OFFSET;
-            std::unique_ptr< Cell > c(new Cell(_buf, offset));
+            auto c = std::make_unique< Cell >(_buf, offset);
 
             if (c.get() == NULL) {
                 throw RegistryParseException("Failed to create Cell.");

--- a/rejistry++/src/DBRecord.cpp
+++ b/rejistry++/src/DBRecord.cpp
@@ -46,7 +46,7 @@ namespace Rejistry {
         uint32_t offset = getDWord(INDIRECT_BLOCK_OFFSET_OFFSET);
         offset += REGFHeader::FIRST_HBIN_OFFSET;
 
-        std::unique_ptr< Cell > c(new Cell(_buf, offset));
+        auto c = std::make_unique< Cell >(_buf, offset);
         if (c.get() == NULL) {
             throw RegistryParseException("Failed to create Cell for DBRecord.");
         }

--- a/rejistry++/src/DirectSubkeyListRecord.cpp
+++ b/rejistry++/src/DirectSubkeyListRecord.cpp
@@ -41,12 +41,12 @@ namespace Rejistry {
             uint32_t relativeOffset = LIST_START_OFFSET + (index * _itemSize);
             uint32_t offset = getDWord(relativeOffset);
             uint32_t parentOffset = REGFHeader::FIRST_HBIN_OFFSET + offset;
-            std::unique_ptr< Cell > c(new Cell(_buf, parentOffset));
+            auto c = std::make_unique< Cell >(_buf, parentOffset);
             if (c.get() == NULL) {
                 throw RegistryParseException("Failed to create Cell for key record.");
             }
 
-            subkeyList.push_back(c->getNKRecord());
+            subkeyList.push_back(c->getNKRecord().release());
         }
 
         return subkeyList;        

--- a/rejistry++/src/DirectSubkeyListRecord.cpp
+++ b/rejistry++/src/DirectSubkeyListRecord.cpp
@@ -33,8 +33,8 @@
 
 namespace Rejistry {
     
-    std::vector<NKRecord *> DirectSubkeyListRecord::getSubkeys() const {
-        std::vector<NKRecord *> subkeyList;
+    NKRecord::NKRecordUniqPtrList DirectSubkeyListRecord::getSubkeys() const {
+        NKRecord::NKRecordUniqPtrList subkeyList;
         uint16_t listLength = getListLength();
 
         for (uint16_t index = 0; index < listLength; ++index) {
@@ -46,10 +46,10 @@ namespace Rejistry {
                 throw RegistryParseException("Failed to create Cell for key record.");
             }
 
-            subkeyList.push_back(c->getNKRecord().release());
+            subkeyList.push_back(c->getNKRecord());
         }
 
-        return subkeyList;        
+        return subkeyList;
     }
 
 };

--- a/rejistry++/src/DirectSubkeyListRecord.cpp
+++ b/rejistry++/src/DirectSubkeyListRecord.cpp
@@ -42,10 +42,6 @@ namespace Rejistry {
             uint32_t offset = getDWord(relativeOffset);
             uint32_t parentOffset = REGFHeader::FIRST_HBIN_OFFSET + offset;
             auto c = std::make_unique< Cell >(_buf, parentOffset);
-            if (c.get() == NULL) {
-                throw RegistryParseException("Failed to create Cell for key record.");
-            }
-
             subkeyList.push_back(c->getNKRecord());
         }
 

--- a/rejistry++/src/DirectSubkeyListRecord.h
+++ b/rejistry++/src/DirectSubkeyListRecord.h
@@ -48,7 +48,7 @@ namespace Rejistry {
         
         virtual ~DirectSubkeyListRecord() {}
     
-        virtual std::vector<NKRecord *> getSubkeys() const;
+        virtual std::vector<std::unique_ptr<NKRecord>> getSubkeys() const;
 
     private:
         static const uint16_t LIST_START_OFFSET = 0x04;

--- a/rejistry++/src/EmptySubkeyList.h
+++ b/rejistry++/src/EmptySubkeyList.h
@@ -46,8 +46,8 @@ namespace Rejistry {
         
         virtual ~EmptySubkeyList() {}
     
-        virtual std::vector<NKRecord *> getSubkeys() const {
-            return std::vector<NKRecord *>();
+        virtual NKRecord::NKRecordUniqPtrList getSubkeys() const {
+            return NKRecord::NKRecordUniqPtrList();
         }
 
     private:

--- a/rejistry++/src/EmptySubkeyList.h
+++ b/rejistry++/src/EmptySubkeyList.h
@@ -45,7 +45,15 @@ namespace Rejistry {
         EmptySubkeyList(RegistryByteBuffer * buf, uint32_t offset) : SubkeyListRecord(buf, offset) {}
         
         virtual ~EmptySubkeyList() {}
-    
+
+        uint16_t getListLength() const override { return 0; }
+
+        /**
+         * Shadows Record::getMagic(). EmptySubkeyList has no valid record
+         * header, so reading the buffer would return garbage bytes.
+         */
+        std::string getMagic() const { return ""; }
+
         virtual NKRecord::NKRecordUniqPtrList getSubkeys() const {
             return NKRecord::NKRecordUniqPtrList();
         }

--- a/rejistry++/src/HBIN.cpp
+++ b/rejistry++/src/HBIN.cpp
@@ -61,6 +61,9 @@ namespace Rejistry {
             }
             cellList.push_back(std::move(nextCell));
             nextCellOffset += cellLen;
+            if (nextCellOffset > hbinSize) {
+                break;
+            }
         }
         while (nextCellOffset < hbinSize);
 

--- a/rejistry++/src/HBIN.cpp
+++ b/rejistry++/src/HBIN.cpp
@@ -40,7 +40,6 @@ namespace Rejistry {
         }
     }
         
-
     uint32_t HBIN::getRelativeOffsetNextHBIN() const {
         return getDWord(NEXT_HBIN_OFFSET_OFFSET);
     }
@@ -49,19 +48,18 @@ namespace Rejistry {
         return getDWord(FIRST_HBIN_OFFSET_OFFSET);
     }
 
-    Cell::CellPtrList HBIN::getCells() const {
+    Cell::CellUniqPtrList HBIN::getCells() const {
         uint32_t nextCellOffset = FIRST_CELL_OFFSET;
-        Cell::CellPtrList cellList;
         uint32_t hbinSize = getRelativeOffsetNextHBIN();
 
+        std::vector <Cell::CellUniqPtr> cellList;
         do {
-            Cell::CellPtr nextCell = new Cell(_buf, getAbsoluteOffset(nextCellOffset));
+            auto nextCell =  std::make_unique<Cell>(_buf, getAbsoluteOffset(nextCellOffset));
             uint32_t cellLen = nextCell->getLength();
             if (cellLen == 0 || nextCellOffset + cellLen < nextCellOffset) {
-                delete nextCell;
                 throw RegistryParseException("Invalid cell length.");
             }
-            cellList.push_back(nextCell);
+            cellList.push_back(std::move(nextCell));
             nextCellOffset += cellLen;
         }
         while (nextCellOffset < hbinSize);
@@ -69,7 +67,7 @@ namespace Rejistry {
         return cellList;
     }
 
-    Cell::CellPtr HBIN::getCellAtOffset(uint32_t offset) const {
-        return new Cell(_buf, getAbsoluteOffset(offset));
+    Cell::CellUniqPtr HBIN::getCellAtOffset(uint32_t offset) const {
+        return std::make_unique<Cell>(_buf, getAbsoluteOffset(offset));
     }
 };

--- a/rejistry++/src/HBIN.cpp
+++ b/rejistry++/src/HBIN.cpp
@@ -61,9 +61,6 @@ namespace Rejistry {
             }
             cellList.push_back(std::move(nextCell));
             nextCellOffset += cellLen;
-            if (nextCellOffset > hbinSize) {
-                break;
-            }
         }
         while (nextCellOffset < hbinSize);
 

--- a/rejistry++/src/HBIN.h
+++ b/rejistry++/src/HBIN.h
@@ -46,42 +46,8 @@ namespace Rejistry {
     class HBIN : public BinaryBlock {
     public:
         typedef HBIN * HBINPtr;
+        typedef std::unique_ptr<HBIN> HBINUniqPtr;
         typedef std::vector< HBINPtr > HBINPtrList;
-
-        /**
-            The AutoHBINPtrList class should be used by clients to hold lists of
-            HBIN pointers returned by methods like REGFHeader::getHBINs()
-            so that the record objects will be automatically freed. Example:
-            @code
-            AutoHBINPtrList hbinList(header->getHBINs());
-            for (HBIN::HBINPtrList::iterator i = hbinList.begin(); i != hbinList.end(); ++i)
-            { ... //do stuff }
-            // Don't worry about delete'ing each record object--valueList will take care of
-            // that when it goes out of scope.
-            @endcode
-        */
-        class AutoHBINPtrList
-        {
-        public:
-
-            AutoHBINPtrList(HBINPtrList recordList) : _recordList(recordList) {}
-            ~AutoHBINPtrList()
-            {
-                for (HBINPtrList::iterator it = _recordList.begin(); it != _recordList.end(); ++it)
-                {
-                    delete *it;
-                }
-            }
-            HBINPtrList::iterator begin() { return _recordList.begin(); }
-            HBINPtrList::iterator end()   { return _recordList.end(); }
-            HBINPtrList::size_type size() { return _recordList.size(); }
-        private:
-            AutoHBINPtrList(const AutoHBINPtrList&);
-            AutoHBINPtrList& operator=(const AutoHBINPtrList&);
-
-            HBINPtrList _recordList;
-        };
-
 
         HBIN(const REGFHeader * header, RegistryByteBuffer * buf, uint32_t offset);
         
@@ -103,19 +69,16 @@ namespace Rejistry {
 
         /**
          * Get all cells in this HBIN.
-         * @returns A list of Cells. The caller is responsible for freeing
-         * the memory associated with the cells.
+         * @returns A list of Cells.
          */
-        Cell::CellPtrList getCells() const;
+        Cell::CellUniqPtrList getCells() const;
 
         /**
          * Get the cell at the given relative offset into this HBIN.
          * @param offset Relative offset into this HBIN.
-         * @returns A pointer to the Cell at the given offset. The 
-         * caller is responsible for freeing the memory associated with
-         * the Cell.
+         * @returns A unqiue pointer to the Cell at the given offset.
          */
-        Cell::CellPtr getCellAtOffset(uint32_t offset) const;
+        Cell::CellUniqPtr getCellAtOffset(uint32_t offset) const;
 
     private:
         static const uint8_t FIRST_HBIN_OFFSET_OFFSET = 0x4;

--- a/rejistry++/src/HBIN.h
+++ b/rejistry++/src/HBIN.h
@@ -45,9 +45,7 @@ namespace Rejistry {
      */
     class HBIN : public BinaryBlock {
     public:
-        typedef HBIN * HBINPtr;
         typedef std::unique_ptr<HBIN> HBINUniqPtr;
-        typedef std::vector< HBINPtr > HBINPtrList;
 
         HBIN(const REGFHeader * header, RegistryByteBuffer * buf, uint32_t offset);
         
@@ -89,7 +87,7 @@ namespace Rejistry {
         HBIN(const HBIN &);
         HBIN& operator=(const HBIN &);
 
-        const REGFHeader * _header = NULL;
+        const REGFHeader * _header = nullptr;
     };
 };
 

--- a/rejistry++/src/NKRecord.cpp
+++ b/rejistry++/src/NKRecord.cpp
@@ -69,7 +69,7 @@ namespace Rejistry {
             throw RegistryParseException("Invalid class name offset.");
         }
         uint32_t classnameOffset = REGFHeader::FIRST_HBIN_OFFSET + (uint32_t)offset;
-        std::unique_ptr< Cell > c(new Cell(_buf, classnameOffset));
+        auto c = std::make_unique< Cell >(_buf, classnameOffset);
         if (c.get() == NULL) {
             throw RegistryParseException("Failed to create cell for class name.");
         }
@@ -123,13 +123,13 @@ namespace Rejistry {
         }
     }
 
-    NKRecord::NKRecordPtr NKRecord::getParentRecord() const {
+    std::unique_ptr<NKRecord> NKRecord::getParentRecord() const {
         int32_t offset = (int32_t)getDWord(PARENT_RECORD_OFFSET_OFFSET);
         if (offset < 0) {
             throw RegistryParseException("Invalid parent record offset.");
         }
         uint32_t parentOffset = REGFHeader::FIRST_HBIN_OFFSET + (uint32_t)offset;
-        std::unique_ptr< Cell > c(new Cell(_buf, parentOffset));
+        auto c = std::make_unique< Cell >(_buf, parentOffset);
 
         if (c.get() == NULL) {
             throw RegistryParseException("Failed to create Cell for parent.");
@@ -161,7 +161,7 @@ namespace Rejistry {
         uint32_t offset = (uint32_t)getDWord(SUBKEY_LIST_OFFSET_OFFSET);
         offset += REGFHeader::FIRST_HBIN_OFFSET;
 
-        std::unique_ptr< Cell > c(new Cell(_buf, offset));
+        auto c = std::make_unique< Cell >(_buf, offset);
 
         if (c.get() == NULL) {
             throw RegistryParseException("Failed to create Cell for value list record.");
@@ -178,7 +178,7 @@ namespace Rejistry {
         uint32_t offset = (uint32_t)getDWord(VALUE_LIST_OFFSET_OFFSET);
         offset += REGFHeader::FIRST_HBIN_OFFSET;
 
-        std::unique_ptr< Cell > c(new Cell(_buf, offset));
+        auto c = std::make_unique< Cell >(_buf, offset);
 
         if (c.get() == NULL) {
             throw RegistryParseException("Failed to create Cell for value list record.");

--- a/rejistry++/src/NKRecord.cpp
+++ b/rejistry++/src/NKRecord.cpp
@@ -57,24 +57,21 @@ namespace Rejistry {
         }
 
         int32_t offset = (int32_t)getDWord(CLASSNAME_OFFSET_OFFSET);
-        uint16_t length = getWord(CLASSNAME_LENGTH_OFFSET);
-
-        // Not sure why we are performing this check. I haven't found any documentation on
-        // a max length for class name or its purpose. 
-        if (length > MAX_NAME_LENGTH) {
-            throw RegistryParseException("Class name exceeds maximum length.");
-        }
-
         if (offset < 0) {
             throw RegistryParseException("Invalid class name offset.");
         }
         uint32_t classnameOffset = REGFHeader::FIRST_HBIN_OFFSET + (uint32_t)offset;
         auto c = std::make_unique< Cell >(_buf, classnameOffset);
         std::vector<uint8_t> data = c->getData();
+
+        uint16_t length = getWord(CLASSNAME_LENGTH_OFFSET);
         if (length > data.size()) {
             throw RegistryParseException("Cell size insufficient for parsing classname.");
         }
-        return std::wstring(data.begin(), data.end());
+
+        // Class names are stored as UTF-16LE. Cast directly to wchar_t rather
+        // than widening each byte individually via the iterator constructor.
+        return std::wstring(reinterpret_cast<const wchar_t*>(data.data()), length / sizeof(wchar_t));
     }
 
     uint64_t NKRecord::getTimestamp() const {

--- a/rejistry++/src/NKRecord.cpp
+++ b/rejistry++/src/NKRecord.cpp
@@ -70,10 +70,6 @@ namespace Rejistry {
         }
         uint32_t classnameOffset = REGFHeader::FIRST_HBIN_OFFSET + (uint32_t)offset;
         auto c = std::make_unique< Cell >(_buf, classnameOffset);
-        if (c.get() == NULL) {
-            throw RegistryParseException("Failed to create cell for class name.");
-        }
-
         std::vector<uint8_t> data = c->getData();
         if (length > data.size()) {
             throw RegistryParseException("Cell size insufficient for parsing classname.");
@@ -130,10 +126,6 @@ namespace Rejistry {
         }
         uint32_t parentOffset = REGFHeader::FIRST_HBIN_OFFSET + (uint32_t)offset;
         auto c = std::make_unique< Cell >(_buf, parentOffset);
-
-        if (c.get() == NULL) {
-            throw RegistryParseException("Failed to create Cell for parent.");
-        }
         return c->getNKRecord();
     }
 
@@ -163,10 +155,6 @@ namespace Rejistry {
 
         auto c = std::make_unique< Cell >(_buf, offset);
 
-        if (c.get() == NULL) {
-            throw RegistryParseException("Failed to create Cell for value list record.");
-        }
-
         return c->getSubkeyList();
     }
 
@@ -179,11 +167,6 @@ namespace Rejistry {
         offset += REGFHeader::FIRST_HBIN_OFFSET;
 
         auto c = std::make_unique< Cell >(_buf, offset);
-
-        if (c.get() == NULL) {
-            throw RegistryParseException("Failed to create Cell for value list record.");
-        }
-
         return c->getValueListRecord(getNumberOfValues());
     }
 };

--- a/rejistry++/src/NKRecord.h
+++ b/rejistry++/src/NKRecord.h
@@ -124,10 +124,10 @@ namespace Rejistry {
 
         /**
          * Get the parent record for this key.
-         * @returns The parent record. (Caller is responsible for freeing)
+         * @returns The parent record.
          * @throws RegistryParseException.
          */
-        NKRecordPtr getParentRecord() const;
+        std::unique_ptr<NKRecord> getParentRecord() const;
 
         /**
          * @returns The number of values for this key.

--- a/rejistry++/src/NKRecord.h
+++ b/rejistry++/src/NKRecord.h
@@ -43,42 +43,8 @@ namespace Rejistry {
      */
     class NKRecord : public Record {
     public:
-        typedef NKRecord * NKRecordPtr;
-        typedef std::vector<NKRecordPtr> NKRecordPtrList;
-
-        /**
-            The AutoNKRecordPtrList class should be used by clients to hold lists of
-            NKRecord pointers returned by methods like SubkeyListRecord::getSubkeys()
-            so that the record objects will be automatically freed. Example:
-            @code
-            AutoNKRecordPtrList subkeyList(nkrecord->getSubkeyList()->getSubkeys());
-            for (NKRecord::NKRecordPtrList::iterator i = subkeyList.begin(); i != subkeyList.end(); ++i)
-            { ... //do stuff }
-            // Don't worry about delete'ing each record object--subkeyList will take care of
-            // that when it goes out of scope.
-            @endcode
-        */
-        class AutoNKRecordPtrList
-        {
-        public:
-
-            AutoNKRecordPtrList(NKRecordPtrList recordList) : _recordList(recordList) {}
-            ~AutoNKRecordPtrList()
-            {
-                for (NKRecordPtrList::iterator it = _recordList.begin(); it != _recordList.end(); ++it)
-                {
-                    delete *it;
-                }
-            }
-            NKRecordPtrList::iterator begin() { return _recordList.begin(); }
-            NKRecordPtrList::iterator end()   { return _recordList.end(); }
-            NKRecordPtrList::size_type size() { return _recordList.size(); }
-        private:
-            AutoNKRecordPtrList(const AutoNKRecordPtrList&);
-            AutoNKRecordPtrList& operator=(const AutoNKRecordPtrList&);
-
-            NKRecordPtrList _recordList;
-        };
+        typedef std::unique_ptr<NKRecord> NKRecordUniqPtr;
+        typedef std::vector<NKRecordUniqPtr> NKRecordUniqPtrList;
 
         NKRecord(RegistryByteBuffer * buf, uint32_t offset);
         NKRecord(const NKRecord& );

--- a/rejistry++/src/REGFHeader.cpp
+++ b/rejistry++/src/REGFHeader.cpp
@@ -100,16 +100,9 @@ namespace Rejistry {
     std::unique_ptr<NKRecord> REGFHeader::getRootNKRecord() const {
         int32_t firstCellOffset = (int32_t)(getDWord(FIRST_KEY_OFFSET_OFFSET));
         auto firstHBIN = getFirstHBIN();
-        if (firstHBIN.get() != NULL) {
-            auto cellPtr = firstHBIN->getCellAtOffset(firstCellOffset);
-
-            if (cellPtr.get() == NULL) {
-                throw RegistryParseException("Failed to get first cell.");
-            }
-            return cellPtr->getNKRecord();
-        }
-        else {
+        if (firstHBIN == nullptr) {
             throw RegistryParseException("Failed to get first HBIN.");
         }
+        return firstHBIN->getCellAtOffset(firstCellOffset)->getNKRecord();
     }
 };

--- a/rejistry++/src/REGFHeader.cpp
+++ b/rejistry++/src/REGFHeader.cpp
@@ -63,9 +63,9 @@ namespace Rejistry {
         return getDWord(LAST_HBIN_OFFSET_OFFSET);
     }
 
-    HBIN::HBINPtrList REGFHeader::getHBINs() const {
+    std::vector<HBIN::HBINUniqPtr> REGFHeader::getHBINs() const {
         uint32_t nextHBINOffset = FIRST_HBIN_OFFSET;
-        HBIN::HBINPtrList hbinList;
+        std::vector<HBIN::HBINUniqPtr> hbinList;
 
         do {
             if (getDWord(nextHBINOffset) != 0x6E696268) {
@@ -73,9 +73,9 @@ namespace Rejistry {
                 break;
             }
 
-            HBIN * nextHBIN = new HBIN(this, _buf, getAbsoluteOffset(nextHBINOffset));
+            auto nextHBIN = std::make_unique<HBIN>(this, _buf, getAbsoluteOffset(nextHBINOffset));
             uint32_t relNext = nextHBIN->getRelativeOffsetNextHBIN();
-            hbinList.push_back(nextHBIN);
+            hbinList.push_back(std::move(nextHBIN));
             if (relNext == 0 || nextHBINOffset + relNext < nextHBINOffset) {
                 break;
             }
@@ -86,22 +86,22 @@ namespace Rejistry {
         return hbinList;
     }
 
-    HBIN::HBINPtr REGFHeader::getFirstHBIN() const {
+    HBIN::HBINUniqPtr REGFHeader::getFirstHBIN() const {
         if (getDWord(FIRST_HBIN_OFFSET) != 0x6E696268) {
             throw RegistryParseException("HBIN magic value not found.");
         }
 
-        return new HBIN(this, _buf, getAbsoluteOffset(FIRST_HBIN_OFFSET));
+        return std::make_unique<HBIN>(this, _buf, getAbsoluteOffset(FIRST_HBIN_OFFSET));
     }
 
     /**
      * @throws RegistryParseException in case of error.
      */
-    NKRecord::NKRecordPtr REGFHeader::getRootNKRecord() const {
+    std::unique_ptr<NKRecord> REGFHeader::getRootNKRecord() const {
         int32_t firstCellOffset = (int32_t)(getDWord(FIRST_KEY_OFFSET_OFFSET));
-        std::unique_ptr< HBIN > firstHBIN(getFirstHBIN());
+        auto firstHBIN = getFirstHBIN();
         if (firstHBIN.get() != NULL) {
-            std::unique_ptr< Cell > cellPtr(firstHBIN->getCellAtOffset(firstCellOffset));
+            auto cellPtr = firstHBIN->getCellAtOffset(firstCellOffset);
 
             if (cellPtr.get() == NULL) {
                 throw RegistryParseException("Failed to get first cell.");

--- a/rejistry++/src/REGFHeader.h
+++ b/rejistry++/src/REGFHeader.h
@@ -71,20 +71,18 @@ namespace Rejistry {
         uint32_t getLastHbinOffset() const;
 
         /**
-         * Get a list of pointers to HBIN records. The caller is
-         * responsible for freeing the records.
-         * @returns A list of pointers to HBIN records.
+         * Get a list of pointers to HBIN records.
+         * @returns A list of unique pointers to HBIN records.
          */
-        HBIN::HBINPtrList getHBINs() const;
+        std::vector<HBIN::HBINUniqPtr> getHBINs() const;
 
         /**
-         * Get a pointer to the first HBIN record. The caller is 
-         * responsible for freeing the record.
-         * @returns A pointer to the first HBIN record.
+         * Get a unique pointer to the first HBIN record.
+         * @returns A unique pointer to the first HBIN record.
          */
-        HBIN::HBINPtr getFirstHBIN() const;
+        HBIN::HBINUniqPtr getFirstHBIN() const;
 
-        NKRecord::NKRecordPtr getRootNKRecord() const;
+        std::unique_ptr<NKRecord> getRootNKRecord() const;
 
     private:
         static const uint8_t MAGIC_OFFSET = 0x0;

--- a/rejistry++/src/RIRecord.cpp
+++ b/rejistry++/src/RIRecord.cpp
@@ -49,10 +49,6 @@ namespace Rejistry {
             uint32_t offset = getDWord(LIST_START_OFFSET + (index * LIST_ENTRY_SIZE));
             uint32_t parentOffset = REGFHeader::FIRST_HBIN_OFFSET + offset;
             auto c = std::make_unique< Cell >(_buf, parentOffset);
-            if (c.get() == NULL) {
-                throw RegistryParseException("Failed to create Cell for key record.");
-            }
-
             subkeyList.push_back(c->getSubkeyList());
         }
 

--- a/rejistry++/src/RIRecord.cpp
+++ b/rejistry++/src/RIRecord.cpp
@@ -48,7 +48,7 @@ namespace Rejistry {
         for (uint16_t index = 0; index < listLength; ++index) {
             uint32_t offset = getDWord(LIST_START_OFFSET + (index * LIST_ENTRY_SIZE));
             uint32_t parentOffset = REGFHeader::FIRST_HBIN_OFFSET + offset;
-            std::unique_ptr< Cell > c(new Cell(_buf, parentOffset));
+            auto c = std::make_unique< Cell >(_buf, parentOffset);
             if (c.get() == NULL) {
                 throw RegistryParseException("Failed to create Cell for key record.");
             }

--- a/rejistry++/src/RIRecord.cpp
+++ b/rejistry++/src/RIRecord.cpp
@@ -59,16 +59,16 @@ namespace Rejistry {
         return subkeyList;
     }
 
-    NKRecord::NKRecordPtrList RIRecord::getSubkeys() const {
-        NKRecord::NKRecordPtrList finalNKRecordList;
-        SubkeyListRecord::SubkeyListRecordPtrList subkeyLists = getSubkeyLists();
+    NKRecord::NKRecordUniqPtrList RIRecord::getSubkeys() const {
+        NKRecord::NKRecordUniqPtrList finalNKRecordList;
 
         // Iterate over each of the subkey lists getting their subkeys.
-        for (const auto& subkeyList : subkeyLists) {
-            NKRecord::NKRecordPtrList nkRecordList = subkeyList->getSubkeys();
-            finalNKRecordList.insert(finalNKRecordList.end(), nkRecordList.begin(), nkRecordList.end());
+        for (const auto& subkeyList : getSubkeyLists()) {
+            for (auto& nk : subkeyList->getSubkeys()) {
+                finalNKRecordList.push_back(std::move(nk));
+            }
         }
 
-        return finalNKRecordList;        
+        return finalNKRecordList;
     }
 };

--- a/rejistry++/src/RIRecord.h
+++ b/rejistry++/src/RIRecord.h
@@ -47,7 +47,7 @@ namespace Rejistry {
         
         virtual ~RIRecord() {}
 
-        virtual NKRecord::NKRecordPtrList getSubkeys() const;
+        virtual std::vector<std::unique_ptr<NKRecord>> getSubkeys() const;
 
     private:
         static const uint16_t LIST_START_OFFSET = 0x04;

--- a/rejistry++/src/Record.h
+++ b/rejistry++/src/Record.h
@@ -57,7 +57,7 @@ namespace Rejistry {
     protected:
         Record() {};
         Record(const Record &) {};
-        Record& operator=(const Record &);
+        Record& operator=(const Record &) = delete;
     };
 
 };

--- a/rejistry++/src/RegistryByteBuffer.cpp
+++ b/rejistry++/src/RegistryByteBuffer.cpp
@@ -44,7 +44,7 @@ namespace Rejistry {
     
     // Take ownership of the passed in buffer
     RegistryByteBuffer::RegistryByteBuffer(std::unique_ptr<ByteBuffer> buffer) {
-        if (buffer == NULL) {
+        if (buffer == nullptr) {
             throw RegistryParseException("Buffer must not be null.");
         }
         _byteBuffer = std::move(buffer);

--- a/rejistry++/src/RegistryByteBuffer.cpp
+++ b/rejistry++/src/RegistryByteBuffer.cpp
@@ -42,21 +42,15 @@ namespace Rejistry {
 
     std::wstring_convert<std::codecvt_utf16<wchar_t, 0x10ffff, std::little_endian>, wchar_t> conv;
     
-    /**
-    * Does NOT make a copy of the passed in buffer, but will free the memory when deleted 
-    */
-    RegistryByteBuffer::RegistryByteBuffer(ByteBuffer * buffer) {
+    // Take ownership of the passed in buffer
+    RegistryByteBuffer::RegistryByteBuffer(std::unique_ptr<ByteBuffer> buffer) {
         if (buffer == NULL) {
             throw RegistryParseException("Buffer must not be null.");
         }
-        _byteBuffer = buffer;
+        _byteBuffer = std::move(buffer);
     }
 
     RegistryByteBuffer::~RegistryByteBuffer() {
-        if (_byteBuffer != NULL) {
-            delete _byteBuffer;
-            _byteBuffer = NULL;
-        }
     }
 
     /**

--- a/rejistry++/src/RegistryByteBuffer.h
+++ b/rejistry++/src/RegistryByteBuffer.h
@@ -30,6 +30,7 @@
 
 #include <cstdint>
 #include <string>
+#include <memory>
 
 // Local includes
 #include "ByteBuffer.h"
@@ -41,7 +42,7 @@ namespace Rejistry {
      */
     class RegistryByteBuffer {
     public:
-        RegistryByteBuffer(ByteBuffer * buffer);
+        RegistryByteBuffer(std::unique_ptr<ByteBuffer> buffer);
         virtual ~RegistryByteBuffer();
 
         uint16_t getWord(const uint32_t offset) const;
@@ -67,7 +68,7 @@ namespace Rejistry {
         RegistryByteBuffer(const RegistryByteBuffer &);
         RegistryByteBuffer& operator=(const RegistryByteBuffer &);
 
-        ByteBuffer * _byteBuffer;
+        std::unique_ptr<ByteBuffer> _byteBuffer;
 
     };
 };

--- a/rejistry++/src/RegistryHive.h
+++ b/rejistry++/src/RegistryHive.h
@@ -46,7 +46,7 @@ namespace Rejistry {
         /**
          * Get the header for this hive.
          */
-        virtual REGFHeader * getHeader() const = 0;
+        virtual std::unique_ptr<REGFHeader> getHeader() const = 0;
 
         /**
          * Virtual destructor to prevent memory leak

--- a/rejistry++/src/RegistryHive.h
+++ b/rejistry++/src/RegistryHive.h
@@ -41,7 +41,7 @@ namespace Rejistry {
         /**
          * Get the root key for this hive.
          */
-        virtual RegistryKey * getRoot() const = 0;
+        virtual std::unique_ptr<RegistryKey> getRoot() const = 0;
 
         /**
          * Get the header for this hive.

--- a/rejistry++/src/RegistryHiveBuffer.cpp
+++ b/rejistry++/src/RegistryHiveBuffer.cpp
@@ -36,24 +36,18 @@ namespace Rejistry {
     * @throws RegistryParseException if memory can't be allocated
     */
     RegistryHiveBuffer::RegistryHiveBuffer(const uint8_t * buffer, const uint32_t size) {
-        _buffer = new RegistryByteBuffer(new ByteBuffer(buffer, size));
+        _buffer = std::make_unique<RegistryByteBuffer>(std::make_unique<ByteBuffer>(buffer, size));
     }
 
     RegistryHiveBuffer::~RegistryHiveBuffer() {
-        if (_buffer != NULL) {
-            delete _buffer;
-            _buffer = NULL;
-        }
     }
 
     RegistryKey * RegistryHiveBuffer::getRoot() const {
-        REGFHeader *header = getHeader();
-        Rejistry::NKRecord *nkRecord = header->getRootNKRecord();
-        delete header;
-        return new RegistryKey(nkRecord);
+        auto header = getHeader();
+        return new RegistryKey(header->getRootNKRecord());
     }
 
-    REGFHeader * RegistryHiveBuffer::getHeader() const {
-        return new REGFHeader(*_buffer, 0x0);
+    std::unique_ptr<REGFHeader> RegistryHiveBuffer::getHeader() const {
+        return std::make_unique< REGFHeader >(*_buffer, 0x0);
     }
 };

--- a/rejistry++/src/RegistryHiveBuffer.cpp
+++ b/rejistry++/src/RegistryHiveBuffer.cpp
@@ -43,8 +43,7 @@ namespace Rejistry {
     }
 
     RegistryKey * RegistryHiveBuffer::getRoot() const {
-        auto header = getHeader();
-        return new RegistryKey(header->getRootNKRecord());
+        return new RegistryKey(getHeader()->getRootNKRecord());
     }
 
     std::unique_ptr<REGFHeader> RegistryHiveBuffer::getHeader() const {

--- a/rejistry++/src/RegistryHiveBuffer.cpp
+++ b/rejistry++/src/RegistryHiveBuffer.cpp
@@ -42,8 +42,8 @@ namespace Rejistry {
     RegistryHiveBuffer::~RegistryHiveBuffer() {
     }
 
-    RegistryKey * RegistryHiveBuffer::getRoot() const {
-        return new RegistryKey(getHeader()->getRootNKRecord());
+    std::unique_ptr <RegistryKey> RegistryHiveBuffer::getRoot() const {
+        return std::make_unique<RegistryKey>(getHeader()->getRootNKRecord());
     }
 
     std::unique_ptr<REGFHeader> RegistryHiveBuffer::getHeader() const {

--- a/rejistry++/src/RegistryHiveBuffer.h
+++ b/rejistry++/src/RegistryHiveBuffer.h
@@ -53,14 +53,14 @@ namespace Rejistry {
         virtual ~RegistryHiveBuffer();
 
         virtual RegistryKey * getRoot() const;
-        virtual REGFHeader * getHeader() const;
+        virtual std::unique_ptr<REGFHeader> getHeader() const;
 
     private:
         RegistryHiveBuffer();
         RegistryHiveBuffer(const RegistryHiveBuffer &);
         RegistryHiveBuffer& operator=(const RegistryHiveBuffer &);
 
-        RegistryByteBuffer * _buffer;
+        std::unique_ptr<RegistryByteBuffer> _buffer;
     };
 };
 

--- a/rejistry++/src/RegistryHiveBuffer.h
+++ b/rejistry++/src/RegistryHiveBuffer.h
@@ -52,7 +52,7 @@ namespace Rejistry {
 
         virtual ~RegistryHiveBuffer();
 
-        virtual RegistryKey * getRoot() const;
+        virtual std::unique_ptr <RegistryKey> getRoot() const;
         virtual std::unique_ptr<REGFHeader> getHeader() const;
 
     private:

--- a/rejistry++/src/RegistryHiveFile.cpp
+++ b/rejistry++/src/RegistryHiveFile.cpp
@@ -65,7 +65,7 @@ namespace Rejistry {
             throw RegistryParseException(getErrorMessage().c_str());
         }
 
-        _buffer = new RegistryByteBuffer(new ByteBuffer((const uint8_t*)mappedFile, (const uint32_t)fileSize.LowPart));
+        _buffer = std::make_unique<RegistryByteBuffer>(std::make_unique<ByteBuffer>((const uint8_t*)mappedFile, (const uint32_t)fileSize.LowPart));
 
         UnmapViewOfFile(mappedFile);
         CloseHandle(fileMappingHandle);
@@ -73,31 +73,28 @@ namespace Rejistry {
     }
 
     RegistryHiveFile::~RegistryHiveFile() {
-        if (_buffer != NULL) {
-            delete _buffer;
-            _buffer = NULL;
-        }
     }
 
     RegistryKey * RegistryHiveFile::getRoot() const {
-        REGFHeader *header = getHeader();
-        NKRecord *nkRecord = header->getRootNKRecord();
-        delete header;
-        return new RegistryKey(nkRecord);
+        return new RegistryKey(getHeader()->getRootNKRecord());
     }
 
-    REGFHeader * RegistryHiveFile::getHeader() const {
-        return new REGFHeader(*_buffer, 0x0);
+    std::unique_ptr<REGFHeader> RegistryHiveFile::getHeader() const {
+        return std::make_unique<REGFHeader>(*_buffer, 0x0);
     }
 
     std::string RegistryHiveFile::getErrorMessage() const {
         DWORD errCode = GetLastError();
-        LPVOID lpMsgBuf;
+        LPVOID lpMsgBuf = NULL;
 
-        FormatMessageA(FORMAT_MESSAGE_ALLOCATE_BUFFER |
+        DWORD result = FormatMessageA(FORMAT_MESSAGE_ALLOCATE_BUFFER |
             FORMAT_MESSAGE_FROM_SYSTEM | FORMAT_MESSAGE_IGNORE_INSERTS,
             NULL, errCode, MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT),
             (LPSTR) &lpMsgBuf, 0, NULL);
+
+        if (lpMsgBuf == nullptr) {
+            return "Unknown error code: " + std::to_string(errCode);
+        }
 
         std::string errMsg((LPSTR)lpMsgBuf);
         LocalFree(lpMsgBuf);

--- a/rejistry++/src/RegistryHiveFile.cpp
+++ b/rejistry++/src/RegistryHiveFile.cpp
@@ -43,6 +43,7 @@ namespace Rejistry {
 
         LARGE_INTEGER fileSize;
         if (!GetFileSizeEx(fileHandle, &fileSize)) {
+            CloseHandle(fileHandle);
             throw RegistryParseException("Failed to get file size.");
         }
 
@@ -75,8 +76,8 @@ namespace Rejistry {
     RegistryHiveFile::~RegistryHiveFile() {
     }
 
-    RegistryKey * RegistryHiveFile::getRoot() const {
-        return new RegistryKey(getHeader()->getRootNKRecord());
+    std::unique_ptr <RegistryKey> RegistryHiveFile::getRoot() const {
+        return std::make_unique <RegistryKey>(getHeader()->getRootNKRecord());
     }
 
     std::unique_ptr<REGFHeader> RegistryHiveFile::getHeader() const {

--- a/rejistry++/src/RegistryHiveFile.h
+++ b/rejistry++/src/RegistryHiveFile.h
@@ -44,7 +44,7 @@ namespace Rejistry {
         virtual ~RegistryHiveFile();
 
         virtual RegistryKey * getRoot() const;
-        virtual REGFHeader * getHeader() const;
+        virtual std::unique_ptr<REGFHeader> getHeader() const;
 
     private:
         RegistryHiveFile();
@@ -52,7 +52,7 @@ namespace Rejistry {
         RegistryHiveFile& operator=(const RegistryHiveFile &);
 
 
-        RegistryByteBuffer * _buffer;
+        std::unique_ptr<RegistryByteBuffer> _buffer;
 
         std::string getErrorMessage() const;
     };

--- a/rejistry++/src/RegistryHiveFile.h
+++ b/rejistry++/src/RegistryHiveFile.h
@@ -43,7 +43,7 @@ namespace Rejistry {
 
         virtual ~RegistryHiveFile();
 
-        virtual RegistryKey * getRoot() const;
+        virtual std::unique_ptr <RegistryKey> getRoot() const;
         virtual std::unique_ptr<REGFHeader> getHeader() const;
 
     private:

--- a/rejistry++/src/RegistryKey.cpp
+++ b/rejistry++/src/RegistryKey.cpp
@@ -49,7 +49,6 @@ namespace Rejistry {
         return _nk->getTimestamp();
     }
 
-
     std::wstring RegistryKey::getName() const {
         return _nk->getName();
     }
@@ -62,64 +61,39 @@ namespace Rejistry {
         return std::make_unique<RegistryKey>(_nk->getParentRecord());
     }
 
-    /**
-     * Caller is responsible for freeing the keys in the list
-     */
     RegistryKey::RegistryKeyPtrList RegistryKey::getSubkeyList() const {
-        std::vector<RegistryKey *> subkeys;
-        SubkeyListRecord::SubkeyListRecordPtr subkeyListRecordPtr = _nk->getSubkeyList();
-        NKRecord::NKRecordPtrList nkRecordList = subkeyListRecordPtr->getSubkeys();
-        NKRecord::NKRecordPtrList::iterator it;
-        for (it = nkRecordList.begin(); it != nkRecordList.end(); ++it) {
-            subkeys.push_back(new RegistryKey(std::unique_ptr<NKRecord>(*it)));
+        std::vector<RegistryKey::RegistryKeyUniqPtr> subkeys;
+        for (auto& nk : _nk->getSubkeyList()->getSubkeys()) {
+            subkeys.push_back(std::make_unique<RegistryKey>(std::move(nk)));
         }
+
         return subkeys;
     }
 
-
     size_t RegistryKey::getSubkeyListSize() const {
-        SubkeyListRecord::SubkeyListRecordPtr subkeyListRecordPtr = _nk->getSubkeyList();
-        NKRecord::NKRecordPtrList nkRecordList = subkeyListRecordPtr->getSubkeys();
-        size_t sz = nkRecordList.size();
-        for (NKRecord::NKRecordPtrList::iterator it = nkRecordList.begin(); it != nkRecordList.end(); ++it) {
-            delete *it;
-        }
-        return sz;
+        return _nk->getSubkeyList()->getListLength();
     }
 
-
-    /**
-     * Caller is responsible for freeing returned key
-     */
-    RegistryKey::RegistryKeyPtr RegistryKey::getSubkey(const std::wstring& name) const {
-        return new RegistryKey(std::unique_ptr<NKRecord>(_nk->getSubkeyList()->getSubkey(name)));
+    RegistryKey::RegistryKeyUniqPtr RegistryKey::getSubkey(const std::wstring& name) const {
+        return std::make_unique<RegistryKey>(_nk->getSubkeyList()->getSubkey(name));
     }
 
-    /**
-     * Caller is responsible for freeing the values in the list
-     */
     RegistryValue::RegistryValuePtrList RegistryKey::getValueList() const {
         RegistryValue::RegistryValuePtrList values;
 
         for (auto& valueRecord : _nk->getValueList()->getValues()) { 
-            values.push_back(new RegistryValue(std::move(valueRecord)));
+            values.push_back(std::make_unique<RegistryValue>(std::move(valueRecord)));
         }
 
         return values;
     }
-
 
     size_t RegistryKey::getValueListSize() const {
         auto valueListRecord = _nk->getValueList();
         return valueListRecord->getValuesSize();
     }
 
-    /**
-     * Caller is responsible for freeing returned value
-     */
-    RegistryValue::RegistryValuePtr RegistryKey::getValue(const std::wstring& name) const {
-        auto valueListRecord = _nk->getValueList();
-        Rejistry::VKRecord *vkRecord = valueListRecord->getValue(name);
-        return new RegistryValue(std::unique_ptr<VKRecord>(vkRecord));
+    RegistryValue::RegistryValueUniqPtr RegistryKey::getValue(const std::wstring& name) const {
+        return std::make_unique<RegistryValue>(_nk->getValueList()->getValue(name));
     }
 };

--- a/rejistry++/src/RegistryKey.cpp
+++ b/rejistry++/src/RegistryKey.cpp
@@ -32,22 +32,17 @@
 
 namespace Rejistry {
     RegistryKey::RegistryKey(const RegistryKey& rk) {
-        _nk = new NKRecord(*(rk._nk));
+        _nk = std::make_unique<NKRecord>(*(rk._nk));
     }
 
     RegistryKey& RegistryKey::operator=(const RegistryKey & rk) {
         if (this != &rk) {
-            delete _nk;
-            _nk = new NKRecord(*(rk._nk));
+            _nk = std::make_unique<NKRecord>(*(rk._nk));
         }
         return *this;
     }
 
     RegistryKey::~RegistryKey() {
-        if (_nk != NULL) {
-            delete _nk;
-            _nk = NULL;
-        }
     }
 
     uint64_t RegistryKey::getTimestamp() const {
@@ -59,15 +54,12 @@ namespace Rejistry {
         return _nk->getName();
     }
 
-    /**
-     * Caller is responsible for freeing the key
-     */
-    RegistryKey::RegistryKeyPtr RegistryKey::getParent() const {
+    std::unique_ptr<RegistryKey> RegistryKey::getParent() const {
         if (!_nk->hasParentRecord()) {
             throw NoSuchElementException("Registry Key has no parent.");
         }
 
-        return new RegistryKey(_nk->getParentRecord());
+        return std::make_unique<RegistryKey>(_nk->getParentRecord());
     }
 
     /**
@@ -79,7 +71,7 @@ namespace Rejistry {
         NKRecord::NKRecordPtrList nkRecordList = subkeyListRecordPtr->getSubkeys();
         NKRecord::NKRecordPtrList::iterator it;
         for (it = nkRecordList.begin(); it != nkRecordList.end(); ++it) {
-            subkeys.push_back(new RegistryKey(*it));
+            subkeys.push_back(new RegistryKey(std::unique_ptr<NKRecord>(*it)));
         }
         return subkeys;
     }
@@ -100,9 +92,7 @@ namespace Rejistry {
      * Caller is responsible for freeing returned key
      */
     RegistryKey::RegistryKeyPtr RegistryKey::getSubkey(const std::wstring& name) const {
-        SubkeyListRecord::SubkeyListRecordPtr subkeyListRecordPtr = _nk->getSubkeyList();
-        Rejistry::NKRecord *nkRecord = subkeyListRecordPtr->getSubkey(name);
-        return new RegistryKey(nkRecord);
+        return new RegistryKey(std::unique_ptr<NKRecord>(_nk->getSubkeyList()->getSubkey(name)));
     }
 
     /**
@@ -110,11 +100,11 @@ namespace Rejistry {
      */
     RegistryValue::RegistryValuePtrList RegistryKey::getValueList() const {
         RegistryValue::RegistryValuePtrList values;
-        auto valueListRecord = _nk->getValueList();
-        VKRecord::VKRecordPtrList vkRecordList = valueListRecord->getValues();
-        for (VKRecord::VKRecordPtrList::iterator it = vkRecordList.begin(); it != vkRecordList.end(); ++it) {
-            values.push_back(new RegistryValue(*it));
+
+        for (auto& valueRecord : _nk->getValueList()->getValues()) { 
+            values.push_back(new RegistryValue(std::move(valueRecord)));
         }
+
         return values;
     }
 
@@ -130,6 +120,6 @@ namespace Rejistry {
     RegistryValue::RegistryValuePtr RegistryKey::getValue(const std::wstring& name) const {
         auto valueListRecord = _nk->getValueList();
         Rejistry::VKRecord *vkRecord = valueListRecord->getValue(name);
-        return new RegistryValue(vkRecord);
+        return new RegistryValue(std::unique_ptr<VKRecord>(vkRecord));
     }
 };

--- a/rejistry++/src/RegistryKey.cpp
+++ b/rejistry++/src/RegistryKey.cpp
@@ -71,7 +71,7 @@ namespace Rejistry {
     }
 
     size_t RegistryKey::getSubkeyListSize() const {
-        return _nk->getSubkeyList()->getListLength();
+        return _nk->getSubkeyCount();
     }
 
     RegistryKey::RegistryKeyUniqPtr RegistryKey::getSubkey(const std::wstring& name) const {

--- a/rejistry++/src/RegistryKey.h
+++ b/rejistry++/src/RegistryKey.h
@@ -45,7 +45,7 @@ namespace Rejistry {
         typedef RegistryKey * RegistryKeyPtr;
         typedef std::vector<RegistryKeyPtr> RegistryKeyPtrList;
 
-        RegistryKey(NKRecord* nk) { _nk = nk; }
+        RegistryKey(std::unique_ptr<NKRecord> nk) { _nk = std::move(nk); }
         RegistryKey(const RegistryKey& );
         RegistryKey& operator=(const RegistryKey &);
 
@@ -61,10 +61,10 @@ namespace Rejistry {
 
         /**
          * Get the parent of the current registry key.
-         * @returns Pointer to parent registry key.
+         * @returns Unqiue pointer to parent registry key.
          * @throws RegistryParseException if parent cannot be found.
          */
-        RegistryKeyPtr getParent() const;
+        std::unique_ptr<RegistryKey> getParent() const;
 
         /**
          * Get all subkeys for the current registry key.
@@ -113,7 +113,7 @@ namespace Rejistry {
     private:
         RegistryKey();
 
-        NKRecord * _nk;
+        std::unique_ptr<NKRecord> _nk;
     };
 };
 

--- a/rejistry++/src/RegistryKey.h
+++ b/rejistry++/src/RegistryKey.h
@@ -42,8 +42,8 @@ namespace Rejistry {
      */
     class RegistryKey {
     public:
-        typedef RegistryKey * RegistryKeyPtr;
-        typedef std::vector<RegistryKeyPtr> RegistryKeyPtrList;
+        typedef std::unique_ptr<RegistryKey> RegistryKeyUniqPtr;
+        typedef std::vector<RegistryKeyUniqPtr> RegistryKeyPtrList;
 
         RegistryKey(std::unique_ptr<NKRecord> nk) { _nk = std::move(nk); }
         RegistryKey(const RegistryKey& );
@@ -83,10 +83,10 @@ namespace Rejistry {
         /**
          * Get the subkey with the given name.
          * @param name ASCII name of the subkey of retrieve.
-         * @returns Pointer to the subkey.
+         * @returns Unique pointer to the subkey.
          * @throws RegistryParseException if subkey cannot be found.
          */
-        RegistryKeyPtr getSubkey(const std::wstring& name) const;
+        RegistryKey::RegistryKeyUniqPtr getSubkey(const std::wstring& name) const;
 
         /**
          * Get all values for the current key.
@@ -108,7 +108,7 @@ namespace Rejistry {
          * @returns Pointer to the value.
          * @throws RegistryParseException on error.
          */
-        RegistryValue::RegistryValuePtr getValue(const std::wstring& name) const;
+        RegistryValue::RegistryValueUniqPtr getValue(const std::wstring& name) const;
 
     private:
         RegistryKey();

--- a/rejistry++/src/RegistryValue.cpp
+++ b/rejistry++/src/RegistryValue.cpp
@@ -45,7 +45,7 @@ namespace Rejistry {
         return _vk->getValueType();
     }
 
-    ValueData * RegistryValue::getValue() const {
+    ValueData::ValueDataUniqPtr RegistryValue::getValue() const {
         return _vk->getValue();
     }
 

--- a/rejistry++/src/RegistryValue.cpp
+++ b/rejistry++/src/RegistryValue.cpp
@@ -31,14 +31,10 @@
 
 namespace Rejistry {
     RegistryValue::RegistryValue(const RegistryValue& rv) {
-        _vk = new VKRecord(*(rv._vk));
+        _vk = std::make_unique<VKRecord>(*(rv._vk));
     }
 
     RegistryValue::~RegistryValue() {
-        if (_vk != NULL) {
-            delete _vk;
-            _vk = NULL;
-        }
     }
 
     std::wstring RegistryValue::getName() const {

--- a/rejistry++/src/RegistryValue.h
+++ b/rejistry++/src/RegistryValue.h
@@ -43,8 +43,8 @@ namespace Rejistry {
     class RegistryValue {
     public:
 
-        typedef RegistryValue * RegistryValuePtr;
-        typedef std::vector<RegistryValuePtr> RegistryValuePtrList;
+        typedef std::unique_ptr<RegistryValue> RegistryValueUniqPtr;
+        typedef std::vector<RegistryValueUniqPtr> RegistryValuePtrList;
 
         RegistryValue(std::unique_ptr<VKRecord> vk) { _vk = std::move(vk); }
         RegistryValue(const RegistryValue& );
@@ -65,10 +65,10 @@ namespace Rejistry {
 
         /**
          * Get the value data.
-         * @returns Pointer to the value data.
+         * @returns Unique pointer to the value data.
          * @throws RegistryParseException on error.
          */
-        ValueData * getValue() const;
+        ValueData::ValueDataUniqPtr getValue() const;
 
         /**
          * Get the length of the value in bytes.

--- a/rejistry++/src/RegistryValue.h
+++ b/rejistry++/src/RegistryValue.h
@@ -46,7 +46,7 @@ namespace Rejistry {
         typedef RegistryValue * RegistryValuePtr;
         typedef std::vector<RegistryValuePtr> RegistryValuePtrList;
 
-        RegistryValue(VKRecord* vk) { _vk = vk; }
+        RegistryValue(std::unique_ptr<VKRecord> vk) { _vk = std::move(vk); }
         RegistryValue(const RegistryValue& );
 
         virtual ~RegistryValue();
@@ -80,7 +80,7 @@ namespace Rejistry {
         RegistryValue();
         RegistryValue& operator=(const RegistryValue &);
 
-        VKRecord * _vk;
+        std::unique_ptr<VKRecord> _vk;
     };
 };
 

--- a/rejistry++/src/Rejistry.cpp
+++ b/rejistry++/src/Rejistry.cpp
@@ -197,6 +197,13 @@ namespace Rejistry {
     }
 
     void processRegistryHive(RegistryHive& hive) {
+        // Save and restore stream flags so repeated calls don't inherit
+        // hex/fill state left behind by printVKRecord/dumpHexString.
+        std::ios_base::fmtflags savedFlags = std::wcout.flags();
+        std::streamsize savedWidth = std::wcout.width(0);
+        wchar_t savedFill = std::wcout.fill(L' ');
+        std::wcout << std::dec;
+
         try {
             auto header = hive.getHeader();
             std::wcout << "hive name: " << header->getHiveName() << std::endl;
@@ -236,6 +243,10 @@ namespace Rejistry {
         catch (std::exception& ex) {
             std::wcout << "processRegistryHive exception: " << ex.what() << std::endl;
         }
+
+        std::wcout.flags(savedFlags);
+        std::wcout.width(savedWidth);
+        std::wcout.fill(savedFill);
     }
 
     void processRegistryBuffer(wchar_t * regFilePath) {

--- a/rejistry++/src/Rejistry.cpp
+++ b/rejistry++/src/Rejistry.cpp
@@ -25,6 +25,7 @@
 #include <codecvt>
 
 #include "RegistryHiveFile.h"
+#include "RegistryHiveBuffer.h"
 #include "Record.h"
 
 namespace Rejistry {
@@ -172,11 +173,9 @@ namespace Rejistry {
             std::wcout << prefix << "nkrecord number of values: " << nkRecord->getNumberOfValues() << std::endl;
             std::wcout << prefix << "nkrecord number of subkeys: " << nkRecord->getSubkeyCount() << std::endl;
 
-            VKRecord::AutoVKRecordPtrList vkList(nkRecord->getValueList()->getValues());
-            VKRecord::VKRecordPtrList::iterator vkIter;
-            for (vkIter = vkList.begin(); vkIter != vkList.end(); ++vkIter) {
-                std::wcout << prefix << "  value: " << (*vkIter)->getName() << std::endl;
-                printVKRecord((*vkIter), L"    " + prefix);
+            for (auto& vkRecord : nkRecord->getValueList()->getValues()) {
+                std::wcout << prefix << "  value: " << vkRecord->getName() << std::endl;
+                printVKRecord(vkRecord.release(), L"    " + prefix);
             }
         }
         catch (std::exception& ex) {
@@ -197,40 +196,34 @@ namespace Rejistry {
 
     }
 
-    void processRegistryFile(wchar_t * regFilePath) {
+    void processRegistryHive(RegistryHive& hive) {
         try {
-            RegistryHiveFile registryFile(regFilePath);
-            REGFHeader * header = registryFile.getHeader();
+            auto header = hive.getHeader();
             std::wcout << "hive name: " << header->getHiveName() << std::endl;
             std::wcout << "major version: " << header->getMajorVersion() << std::endl;
             std::wcout << "minor version: " << header->getMinorVersion() << std::endl;
-            std::wcout << "hive sync: " << (header->isSynchronized() == true ? "Yes" : "No") << std::endl;
+            std::wcout << "hive sync: " << (header->isSynchronized() ? "Yes" : "No") << std::endl;
 
-            HBIN::AutoHBINPtrList hbinList (header->getHBINs());
+            auto hbinList(header->getHBINs());
             std::wcout << "number of hbins: " << hbinList.size() << std::endl;
-
             std::wcout << "last hbin offset: " << header->getLastHbinOffset() << std::endl;
 
-            HBIN::HBINPtrList::iterator it;
             int i = 0;
-            for (it = hbinList.begin(); it != hbinList.end(); ++it) {
-                std::wcout << "hbin " << i << ", relative offset first hbin: " << (*it)->getRelativeOffsetFirstHBIN() << std::endl;
-                std::wcout << "hbin " << i << ", relative offset next hbin: " << (*it)->getRelativeOffsetNextHBIN() << std::endl;
+            for (auto& hbin : hbinList) {
+                std::wcout << "hbin " << i << ", relative offset first hbin: " << hbin->getRelativeOffsetFirstHBIN() << std::endl;
+                std::wcout << "hbin " << i << ", relative offset next hbin: " << hbin->getRelativeOffsetNextHBIN() << std::endl;
 
-                Cell::AutoCellPtrList cellList((*it)->getCells());
-                Cell::CellPtrList::iterator cellIter;
                 int j = 0;
-                for (cellIter = cellList.begin(); cellIter != cellList.end(); ++cellIter) {
-                    std::wcout << "hbin " << i << ", cell " << j << ", is allocated: " << ((*cellIter)->isActive() ? "yes" : "no") << std::endl;
-                    std::wcout << "hbin " << i << ", cell " << j << ", length: " << (*cellIter)->getLength() << std::endl;
+                for (auto& cell : hbin->getCells()) {
+                    std::wcout << "hbin " << i << ", cell " << j << ", is allocated: " << (cell->isActive() ? "yes" : "no") << std::endl;
+                    std::wcout << "hbin " << i << ", cell " << j << ", length: " << cell->getLength() << std::endl;
                     j++;
                 }
-
                 i++;
             }
 
-            printNKRecord(header->getRootNKRecord(), L"root ");
-            
+            printNKRecord(header->getRootNKRecord().release(), L"root ");
+
             NKRecord::AutoNKRecordPtrList nkRecordList((header->getRootNKRecord()->getSubkeyList()->getSubkeys()));
             NKRecord::NKRecordPtrList::iterator keyIter = nkRecordList.begin();
             for (; keyIter != nkRecordList.end(); ++keyIter) {
@@ -238,7 +231,45 @@ namespace Rejistry {
                 printNKRecord((*keyIter), L"    ");
             }
 
-            recurseNKRecord(header->getRootNKRecord(), L"");
+            recurseNKRecord(header->getRootNKRecord().release(), L"");
+        }
+        catch (std::exception& ex) {
+            std::wcout << "processRegistryHive exception: " << ex.what() << std::endl;
+        }
+    }
+
+    void processRegistryBuffer(wchar_t * regFilePath) {
+        // Read entire file into memory
+        std::ifstream file(regFilePath, std::ios::binary | std::ios::ate);
+        if (!file.is_open()) {
+            std::wcout << "processRegistryBuffer: failed to open file" << std::endl;
+            return;
+        }
+
+        std::streamsize size = file.tellg();
+        file.seekg(0, std::ios::beg);
+
+        std::vector<uint8_t> buffer(static_cast<size_t>(size));
+        if (!file.read(reinterpret_cast<char*>(buffer.data()), size)) {
+            std::wcout << "processRegistryBuffer: failed to read file" << std::endl;
+            return;
+        }
+
+        try {
+            std::wcout << L"=== RegistryHiveBuffer ===" << std::endl;
+            RegistryHiveBuffer hiveBuffer(buffer.data(), static_cast<uint32_t>(size));
+            processRegistryHive(hiveBuffer);
+        }
+        catch (std::exception& ex) {
+            std::wcout << "processRegistryBuffer exception: " << ex.what() << std::endl;
+        }
+    }
+
+    void processRegistryFile(wchar_t * regFilePath) {
+        try {
+            std::wcout << L"=== RegistryHiveFile ===" << std::endl;
+            RegistryHiveFile registryFile(regFilePath);
+            processRegistryHive(registryFile);
         }
         catch (std::exception& ex) {
             std::wcout << "processRegistryFile exception: " << ex.what() << std::endl;
@@ -254,5 +285,7 @@ int wmain(int argc, wchar_t *argv[], wchar_t *envp[])
     }
 
     std::wcout.imbue(std::locale(std::wcout.getloc(), new std::codecvt_utf8_utf16<wchar_t>()));
+
     Rejistry::processRegistryFile(argv[1]);
+    Rejistry::processRegistryBuffer(argv[1]);
 }

--- a/rejistry++/src/Rejistry.cpp
+++ b/rejistry++/src/Rejistry.cpp
@@ -219,33 +219,6 @@ namespace Rejistry {
         std::wcout.fill(savedFill);
     }
 
-    void processRegistryBuffer(wchar_t * regFilePath) {
-        // Read entire file into memory
-        std::ifstream file(regFilePath, std::ios::binary | std::ios::ate);
-        if (!file.is_open()) {
-            std::wcout << "processRegistryBuffer: failed to open file" << std::endl;
-            return;
-        }
-
-        std::streamsize size = file.tellg();
-        file.seekg(0, std::ios::beg);
-
-        std::vector<uint8_t> buffer(static_cast<size_t>(size));
-        if (!file.read(reinterpret_cast<char*>(buffer.data()), size)) {
-            std::wcout << "processRegistryBuffer: failed to read file" << std::endl;
-            return;
-        }
-
-        try {
-            std::wcout << L"=== RegistryHiveBuffer ===" << std::endl;
-            RegistryHiveBuffer hiveBuffer(buffer.data(), static_cast<uint32_t>(size));
-            processRegistryHive(hiveBuffer);
-        }
-        catch (std::exception& ex) {
-            std::wcout << "processRegistryBuffer exception: " << ex.what() << std::endl;
-        }
-    }
-
     void processRegistryFile(wchar_t * regFilePath) {
         try {
             std::wcout << L"=== RegistryHiveFile ===" << std::endl;
@@ -280,5 +253,4 @@ int wmain(int argc, wchar_t *argv[], wchar_t *envp[])
     }
 
     Rejistry::processRegistryFile(argv[1]);
-    Rejistry::processRegistryBuffer(argv[1]);
 }

--- a/rejistry++/src/Rejistry.cpp
+++ b/rejistry++/src/Rejistry.cpp
@@ -113,7 +113,7 @@ namespace Rejistry {
     }
 
 
-    void printVKRecord(const VKRecord::VKRecordPtr vkRecord, const std::wstring& prefix) {
+    void printVKRecord(const VKRecord* vkRecord, const std::wstring& prefix) {
         try {
 
             std::wcout << prefix << "vkrecord has name: " << getBooleanString(vkRecord->hasName()) << std::endl;
@@ -122,7 +122,7 @@ namespace Rejistry {
             std::wcout << prefix << "vkrecord value type: " << ValueData::getValueType(vkRecord->getValueType()) << std::endl;
             std::wcout << prefix << "vkrecord data length: " << std::dec << vkRecord->getDataLength() << std::endl;
 
-            ValueData::ValueDataPtr data = vkRecord->getValue();
+            ValueData::ValueDataUniqPtr data = vkRecord->getValue();
             std::wcout << prefix << "vkrecord data: ";
 
             switch (data->getValueType()) {
@@ -162,7 +162,7 @@ namespace Rejistry {
         }
     }
 
-    void printNKRecord(const NKRecord::NKRecordPtr nkRecord, const std::wstring& prefix) {
+    void printNKRecord(const NKRecord* nkRecord, const std::wstring& prefix) {
         try {
             std::wcout << prefix << "nkrecord has classname: " << getBooleanString(nkRecord->hasClassname()) << std::endl;
             std::wcout << prefix << "nkrecord classname: " << nkRecord->getClassName() << std::endl;
@@ -175,7 +175,7 @@ namespace Rejistry {
 
             for (auto& vkRecord : nkRecord->getValueList()->getValues()) {
                 std::wcout << prefix << "  value: " << vkRecord->getName() << std::endl;
-                printVKRecord(vkRecord.release(), L"    " + prefix);
+                printVKRecord(vkRecord.get(), L"    " + prefix);
             }
         }
         catch (std::exception& ex) {
@@ -183,17 +183,14 @@ namespace Rejistry {
         }
     }
 
-    void recurseNKRecord(NKRecord::NKRecordPtr nkRecord, const std::wstring& prefix) {
+    void recurseNKRecord(NKRecord* nkRecord, const std::wstring& prefix) {
         printNKRecord(nkRecord, prefix);
 
-        NKRecord::AutoNKRecordPtrList subkeyList(nkRecord->getSubkeyList()->getSubkeys());
-        NKRecord::NKRecordPtrList::iterator it = subkeyList.begin();
-
-        for (; it != subkeyList.end(); ++it) {
-            std::wcout << prefix << "  key: " << (*it)->getName() << std::endl;
-            recurseNKRecord((*it), L"    " + prefix);
+        NKRecord::NKRecordUniqPtrList subkeyList = nkRecord->getSubkeyList()->getSubkeys();
+        for (auto& nk : subkeyList) {
+            std::wcout << prefix << "  key: " << nk->getName() << std::endl;
+            recurseNKRecord(nk.get(), L"    " + prefix);
         }
-
     }
 
     void processRegistryHive(RegistryHive& hive) {
@@ -229,16 +226,8 @@ namespace Rejistry {
                 i++;
             }
 
-            printNKRecord(header->getRootNKRecord().release(), L"root ");
-
-            NKRecord::AutoNKRecordPtrList nkRecordList((header->getRootNKRecord()->getSubkeyList()->getSubkeys()));
-            NKRecord::NKRecordPtrList::iterator keyIter = nkRecordList.begin();
-            for (; keyIter != nkRecordList.end(); ++keyIter) {
-                std::wcout << L"  " << (*keyIter)->getName() << std::endl;
-                printNKRecord((*keyIter), L"    ");
-            }
-
-            recurseNKRecord(header->getRootNKRecord().release(), L"");
+            auto root = header->getRootNKRecord();
+            recurseNKRecord(root.get(), L"");
         }
         catch (std::exception& ex) {
             std::wcout << "processRegistryHive exception: " << ex.what() << std::endl;

--- a/rejistry++/src/Rejistry.cpp
+++ b/rejistry++/src/Rejistry.cpp
@@ -14,26 +14,45 @@
 
 /**
  * \file Rejistry.cpp
- * This is a test driver for the Rejistry++ library.
+ * Test driver for the Rejistry++ library.
+ *
+ * Exercises all public APIs (low-level NKRecord/VKRecord and high-level
+ * RegistryKey/RegistryValue) in a single pass. Output is deterministic
+ * and diffable against a known-good baseline to detect regressions.
+ *
+ * High-level RegistryKey/RegistryValue fields are compared against their
+ * low-level equivalents; output is only produced on MISMATCH.  APIs that
+ * are unique to the high-level layer (named lookups, getParent) are
+ * always printed.
  */
 #include <iostream>
 #include <fstream>
 #include <iomanip>
+#include <algorithm>
+#include <chrono>
+#include <map>
+#define NOMINMAX
 #include <Windows.h>
 #include <io.h>
 #include <fcntl.h>
+#include <malloc.h>  // _resetstkoflw
 
 #include "RegistryHiveFile.h"
 #include "RegistryHiveBuffer.h"
+#include "RegistryKey.h"
 #include "Record.h"
 
 namespace Rejistry {
+
+    // -----------------------------------------------------------------------
+    // Helpers
+    // -----------------------------------------------------------------------
+
     std::wstring getBooleanString(bool b) {
         return (b ? L"True" : L"False");
     }
 
     void printDatetimeString(const uint64_t& dateTime) {
-
         SYSTEMTIME systemTime;
         FileTimeToSystemTime((LPFILETIME)&dateTime, &systemTime);
 
@@ -93,15 +112,78 @@ namespace Rejistry {
         }
     }
 
+    // -----------------------------------------------------------------------
+    // Summary statistics — accumulated during traversal, printed at end
+    // -----------------------------------------------------------------------
+
+    struct HiveStats {
+        // HBIN / Cell counts (populated in processRegistryHive HBIN loop)
+        uint32_t hbinCount = 0;
+        uint32_t cellTotal = 0;
+        uint32_t cellAllocated = 0;
+        uint32_t cellUnallocated = 0;
+        std::map<std::string, uint32_t> cellTypeCounts;  // signature -> count (allocated only)
+
+        // Key / Subkey counts (populated in recurseAll)
+        uint32_t keyCount = 0;
+        std::map<std::string, uint32_t> subkeyListMagicCounts;  // magic -> count
+
+        // Value counts (populated in recurseAll)
+        uint32_t valueTotal = 0;
+        std::map<std::wstring, uint32_t> valueTypeCounts;  // type name -> count
+
+        // Extremes
+        uint32_t maxSubkeysForKey = 0;
+        uint32_t maxValuesForKey = 0;
+        uint32_t deepestLevel = 0;
+
+        void print() const {
+            std::wcout << std::endl << L"=== Hive Summary ===" << std::endl;
+            std::wcout << L"Number of HBIN records: " << std::dec << hbinCount << std::endl;
+
+            std::wcout << L"Number of cells (total): " << cellTotal << std::endl;
+            std::wcout << L"  Allocated: " << cellAllocated << std::endl;
+            std::wcout << L"  Unallocated: " << cellUnallocated << std::endl;
+            std::wcout << L"  Allocated cell types:" << std::endl;
+            for (auto& kv : cellTypeCounts) {
+                std::wcout << L"    " << kv.first.c_str() << L": " << kv.second << std::endl;
+            }
+
+            std::wcout << L"Number of keys enumerated: " << keyCount << std::endl;
+            std::wcout << L"  Subkey list magic breakdown:" << std::endl;
+            for (auto& kv : subkeyListMagicCounts) {
+                std::wstring label = kv.first.empty() ? L"(empty)" : std::wstring(kv.first.begin(), kv.first.end());
+                std::wcout << L"    " << label << L": " << kv.second << std::endl;
+            }
+
+            std::wcout << L"Number of values enumerated: " << valueTotal << std::endl;
+            std::wcout << L"  Value type breakdown:" << std::endl;
+            for (auto& kv : valueTypeCounts) {
+                std::wcout << L"    " << kv.first << L": " << kv.second << std::endl;
+            }
+
+            std::wcout << L"Largest number of subkeys for a key: " << maxSubkeysForKey << std::endl;
+            std::wcout << L"Largest number of values for a key: " << maxValuesForKey << std::endl;
+            std::wcout << L"Deepest subkey level: " << deepestLevel << std::endl;
+        }
+    };
+
+    // Global stats instance — reset per hive
+    static HiveStats g_stats;
+
+    // -----------------------------------------------------------------------
+    // Low-level record printing
+    // -----------------------------------------------------------------------
 
     void printVKRecord(const VKRecord* vkRecord, const std::wstring& prefix) {
         try {
-
+            std::wcout << prefix << "vkrecord name: " << vkRecord->getName() << std::endl;
             std::wcout << prefix << "vkrecord has name: " << getBooleanString(vkRecord->hasName()) << std::endl;
             std::wcout << prefix << "vkrecord has ascii name: " << getBooleanString(vkRecord->hasAsciiName()) << std::endl;
-            std::wcout << prefix << "vkrecord name: " << vkRecord->getName() << std::endl;
             std::wcout << prefix << "vkrecord value type: " << ValueData::getValueType(vkRecord->getValueType()) << std::endl;
             std::wcout << prefix << "vkrecord data length: " << std::dec << vkRecord->getDataLength() << std::endl;
+            std::wcout << prefix << "vkrecord raw data length: " << std::dec << vkRecord->getRawDataLength() << std::endl;
+            std::wcout << prefix << "vkrecord data offset: " << std::dec << vkRecord->getDataOffset() << std::endl;
 
             ValueData::ValueDataUniqPtr data = vkRecord->getValue();
             std::wcout << prefix << "vkrecord data: ";
@@ -150,31 +232,330 @@ namespace Rejistry {
             std::wcout << prefix << "nkrecord timestamp: "; printDatetimeString(nkRecord->getTimestamp()); std::wcout << std::endl;
             std::wcout << prefix << "nkrecord is root: " << getBooleanString(nkRecord->isRootKey()) << std::endl;
             std::wcout << prefix << "nkrecord name: " << nkRecord->getName() << std::endl;
+            std::wcout << prefix << "nkrecord has ascii name: " << getBooleanString(nkRecord->hasAsciiName()) << std::endl;
             std::wcout << prefix << "nkrecord has parent: " << getBooleanString(nkRecord->hasParentRecord()) << std::endl;
-            std::wcout << prefix << "nkrecord number of values: " << nkRecord->getNumberOfValues() << std::endl;
-            std::wcout << prefix << "nkrecord number of subkeys: " << nkRecord->getSubkeyCount() << std::endl;
-
-            for (auto& vkRecord : nkRecord->getValueList()->getValues()) {
-                std::wcout << prefix << "  value: " << vkRecord->getName() << std::endl;
-                printVKRecord(vkRecord.get(), L"    " + prefix);
+            if (nkRecord->hasParentRecord()) {
+                try {
+                    auto parent = nkRecord->getParentRecord();
+                    std::wcout << prefix << "nkrecord parent name: " << parent->getName() << std::endl;
+                }
+                catch (std::exception& ex) {
+                    std::wcout << prefix << "nkrecord parent name: exception (" << ex.what() << ")" << std::endl;
+                }
             }
+            else {
+                std::wcout << prefix << "nkrecord parent name: (root)" << std::endl;
+            }
+
+            std::wcout << prefix << "nkrecord number of values: " << std::dec << nkRecord->getNumberOfValues() << std::endl;
+            std::wcout << prefix << "nkrecord number of subkeys: " << std::dec << nkRecord->getSubkeyCount() << std::endl;
         }
         catch (std::exception& ex) {
             std::wcout << "printNKRecord exception: " << ex.what() << std::endl;
         }
     }
 
-    void recurseNKRecord(NKRecord* nkRecord, const std::wstring& prefix) {
-        printNKRecord(nkRecord, prefix);
+    // -----------------------------------------------------------------------
+    // Cross-layer value checks (RegistryValue vs VKRecord)
+    // Only prints on mismatch. Calls all RegistryValue APIs.
+    // -----------------------------------------------------------------------
 
-        NKRecord::NKRecordUniqPtrList subkeyList = nkRecord->getSubkeyList()->getSubkeys();
-        for (auto& nk : subkeyList) {
-            std::wcout << prefix << "  key: " << nk->getName() << std::endl;
-            recurseNKRecord(nk.get(), L"    " + prefix);
+    void crossCheckValues(const VKRecord::VKRecordUniqPtrList& vkRecords,
+                          const RegistryValue::RegistryValuePtrList& rvList,
+                          const std::wstring& prefix) {
+        if (vkRecords.size() != rvList.size()) {
+            std::wcout << prefix << "MISMATCH value list size: nk=" << vkRecords.size()
+                << " rk=" << rvList.size() << std::endl;
+        }
+
+        size_t count = std::min(vkRecords.size(), rvList.size());
+        for (size_t i = 0; i < count; ++i) {
+            try {
+                const VKRecord* vk = vkRecords[i].get();
+                const RegistryValue& rv = *rvList[i];
+
+                // RegistryValue::getName() vs VKRecord::getName()
+                std::wstring vkName = vk->getName();
+                std::wstring rvName = rv.getName();
+                if (vkName != rvName) {
+                    std::wcout << prefix << "MISMATCH regval name: vk=\"" << vkName
+                        << "\" rv=\"" << rvName << "\"" << std::endl;
+                }
+
+                // RegistryValue::getValueType() vs VKRecord::getValueType()
+                ValueData::VALUE_TYPES vkType = vk->getValueType();
+                ValueData::VALUE_TYPES rvType = rv.getValueType();
+                if (vkType != rvType) {
+                    std::wcout << prefix << "MISMATCH regval \"" << vkName << "\" type: vk="
+                        << ValueData::getValueType(vkType) << " rv="
+                        << ValueData::getValueType(rvType) << std::endl;
+                }
+
+                // RegistryValue::getValueLength() vs VKRecord::getDataLength()
+                uint32_t vkLen = vk->getDataLength();
+                uint32_t rvLen = rv.getValueLength();
+                if (vkLen != rvLen) {
+                    std::wcout << prefix << "MISMATCH regval \"" << vkName << "\" length: vk="
+                        << std::dec << vkLen << " rv=" << rvLen << std::endl;
+                }
+
+                // RegistryValue::getValue() — exercise the method, compare data
+                try {
+                    auto rvData = rv.getValue();
+                    auto vkData = vk->getValue();
+
+                    // Compare via getAsRawData() for a type-agnostic byte comparison
+                    auto rvRaw = rvData->getAsRawData();
+                    auto vkRaw = vkData->getAsRawData();
+                    if (rvRaw != vkRaw) {
+                        std::wcout << prefix << "MISMATCH regval \"" << vkName
+                            << "\" data: vk size=" << vkRaw.size()
+                            << " rv size=" << rvRaw.size() << std::endl;
+                    }
+                }
+                catch (std::exception& ex) {
+                    std::wcout << prefix << "crossCheckValues getValue exception for \""
+                        << vkName << "\": " << ex.what() << std::endl;
+                }
+            }
+            catch (std::exception& ex) {
+                std::wcout << prefix << "crossCheckValues exception at index " << i
+                    << ": " << ex.what() << std::endl;
+            }
         }
     }
 
+    // -----------------------------------------------------------------------
+    // Single-pass recursive traversal: low-level + high-level + cross-checks
+    // -----------------------------------------------------------------------
+    void recurseAll(NKRecord* nkRecord, const RegistryKey& regKey, const std::wstring& prefix, uint32_t depth = 0) {
+
+        // --- Stats: count this key, track depth ---
+        g_stats.keyCount++;
+        if (depth > g_stats.deepestLevel) {
+            g_stats.deepestLevel = depth;
+        }
+
+        // --- Low-level NKRecord details ---
+        printNKRecord(nkRecord, prefix);
+
+        // --- Low-level VKRecord details + ValueListRecord checks ---
+        VKRecord::VKRecordUniqPtrList vkRecords;
+        try {
+            auto valueListRecord = nkRecord->getValueList();
+            size_t valueListSize = valueListRecord->getValuesSize();
+            std::wcout << prefix << "nkrecord value list size: " << std::dec << valueListSize << std::endl;
+            uint32_t reportedValues = nkRecord->getNumberOfValues();
+            if (valueListSize != reportedValues) {
+                std::wcout << prefix << "MISMATCH [" << nkRecord->getName()
+                    << "] getNumberOfValues()=" << reportedValues
+                    << " != getValuesSize()=" << valueListSize << std::endl;
+            }
+
+            vkRecords = valueListRecord->getValues();
+            g_stats.valueTotal += static_cast<uint32_t>(vkRecords.size());
+            if (vkRecords.size() > g_stats.maxValuesForKey) {
+                g_stats.maxValuesForKey = static_cast<uint32_t>(vkRecords.size());
+            }
+            for (auto& vkRecord : vkRecords) {
+                std::wcout << prefix << "  value: " << vkRecord->getName() << std::endl;
+                printVKRecord(vkRecord.get(), L"    " + prefix);
+                try {
+                    g_stats.valueTypeCounts[ValueData::getValueType(vkRecord->getValueType())]++;
+                }
+                catch (...) {
+                    g_stats.valueTypeCounts[L"(unknown)"]++;
+                }
+            }
+        }
+        catch (std::exception& ex) {
+            std::wcout << prefix << "recurseAll getValues exception: " << ex.what() << std::endl;
+        }
+
+        // --- SubkeyListRecord metadata ---
+        NKRecord::NKRecordUniqPtrList nkSubkeys;
+        try {
+            uint32_t subkeyCount = nkRecord->getSubkeyCount();
+            auto subkeyListRecord = nkRecord->getSubkeyList();
+
+            std::string magic = subkeyListRecord->getMagic();
+            std::wcout << prefix << "nkrecord subkey list magic: " << magic.c_str() << std::endl;
+            uint16_t listLength = subkeyListRecord->getListLength();
+            std::wcout << prefix << "nkrecord subkey list length: " << std::dec << listLength << std::endl;
+
+            g_stats.subkeyListMagicCounts[magic]++;
+            if (subkeyCount > g_stats.maxSubkeysForKey) {
+                g_stats.maxSubkeysForKey = subkeyCount;
+            }
+
+            if (listLength != subkeyCount) {
+                // RI records: getListLength() returns the number of child
+                // sub-lists (LH/LF/LI segments), not the total subkey count.
+                if (magic != "ri") {
+                    // LF/LH/LI records: getListLength() should equal
+                    // getSubkeyCount(). A mismatch indicates corruption.
+                    std::wcout << prefix << "MISMATCH [" << nkRecord->getName()
+                        << "] getSubkeyCount()=" << subkeyCount
+                        << " != getListLength()=" << listLength << std::endl;
+                }
+            }
+
+            nkSubkeys = subkeyListRecord->getSubkeys();
+        }
+        catch (std::exception& ex) {
+            std::wcout << prefix << "recurseAll getSubkeyList exception: " << ex.what() << std::endl;
+        }
+
+        // --- High-level cross-layer checks (only print on mismatch) ---
+        RegistryKey::RegistryKeyPtrList rkSubkeys;
+        try {
+            // RegistryKey::getName() vs NKRecord::getName()
+            std::wstring nkName = nkRecord->getName();
+            std::wstring rkName = regKey.getName();
+            if (nkName != rkName) {
+                std::wcout << prefix << "MISMATCH regkey name: nk=\"" << nkName
+                    << "\" rk=\"" << rkName << "\"" << std::endl;
+            }
+
+            // RegistryKey::getTimestamp() vs NKRecord::getTimestamp()
+            uint64_t nkTs = nkRecord->getTimestamp();
+            uint64_t rkTs = regKey.getTimestamp();
+            if (nkTs != rkTs) {
+                std::wcout << prefix << "MISMATCH regkey timestamp: nk=" << nkTs
+                    << " rk=" << rkTs << std::endl;
+            }
+
+            // RegistryKey::getSubkeyListSize() vs NKRecord::getSubkeyCount()
+            size_t rkSubkeySize = regKey.getSubkeyListSize();
+            uint32_t nkSubkeyCount = nkRecord->getSubkeyCount();
+            if (rkSubkeySize != nkSubkeyCount) {
+                std::wcout << prefix << "MISMATCH regkey subkey count: nk=" << nkSubkeyCount
+                    << " rk=" << rkSubkeySize << std::endl;
+            }
+
+            // RegistryKey::getSubkeyList().size() vs NKRecord subkeys size
+            rkSubkeys = regKey.getSubkeyList();
+            if (rkSubkeys.size() != nkSubkeys.size()) {
+                std::wcout << prefix << "MISMATCH regkey subkey list count: nk=" << nkSubkeys.size()
+                    << " rk=" << rkSubkeys.size() << std::endl;
+            }
+
+            // RegistryKey::getSubkeyListSize() vs getSubkeyList().size()
+            if (rkSubkeySize != rkSubkeys.size()) {
+                std::wcout << prefix << "MISMATCH regkey subkey list size vs count: size="
+                    << rkSubkeySize << " count=" << rkSubkeys.size() << std::endl;
+            }
+
+            // RegistryKey::getValueListSize() vs NKRecord::getNumberOfValues()
+            size_t rkValueSize = regKey.getValueListSize();
+            uint32_t nkValueCount = nkRecord->getNumberOfValues();
+            if (rkValueSize != nkValueCount) {
+                std::wcout << prefix << "MISMATCH regkey value count: nk=" << nkValueCount
+                    << " rk=" << rkValueSize << std::endl;
+            }
+
+            // RegistryKey::getValueList() vs VKRecord list
+            auto rkValues = regKey.getValueList();
+            if (rkValues.size() != vkRecords.size()) {
+                std::wcout << prefix << "MISMATCH regkey value list count: nk=" << vkRecords.size()
+                    << " rk=" << rkValues.size() << std::endl;
+            }
+
+            // RegistryKey::getValueListSize() vs getValueList().size()
+            if (rkValueSize != rkValues.size()) {
+                std::wcout << prefix << "MISMATCH regkey value list size vs count: size="
+                    << rkValueSize << " count=" << rkValues.size() << std::endl;
+            }
+
+            // Cross-check individual values (RegistryValue vs VKRecord)
+            crossCheckValues(vkRecords, rkValues, prefix);
+
+            // RegistryKey::getParent() — unique to high-level API
+            if (nkRecord->hasParentRecord()) {
+                try {
+                    auto rkParent = regKey.getParent();
+                    auto nkParent = nkRecord->getParentRecord();
+                    if (rkParent->getName() != nkParent->getName()) {
+                        std::wcout << prefix << "MISMATCH regkey parent name: nk=\""
+                            << nkParent->getName() << "\" rk=\""
+                            << rkParent->getName() << "\"" << std::endl;
+                    }
+                }
+                catch (std::exception& ex) {
+                    std::wcout << prefix << "regkey getParent exception: " << ex.what() << std::endl;
+                }
+            }
+        }
+        catch (std::exception& ex) {
+            std::wcout << prefix << "recurseAll cross-check exception: " << ex.what() << std::endl;
+        }
+
+        // --- Named lookups (unique to high-level API, always printed) ---
+        // Cap at MAX_NAMED_LOOKUPS to avoid O(n^2) on large subkey lists
+        // (e.g. RI records with 600+ subkeys where each getSubkey() call
+        // materializes the entire subkey list).
+        static const size_t MAX_NAMED_LOOKUPS = 10;
+
+        {
+            size_t lookupCount = std::min(nkSubkeys.size(), MAX_NAMED_LOOKUPS);
+            for (size_t idx = 0; idx < lookupCount; ++idx) {
+                std::wstring name = nkSubkeys[idx]->getName();
+                try {
+                    auto looked = regKey.getSubkey(name);
+                }
+                catch (std::exception& ex) {
+                    std::wcout << prefix << "  subkey lookup \"" << name << "\": FAILED. exception ("
+                        << ex.what() << ")" << std::endl;
+                }
+            }
+            if (nkSubkeys.size() > MAX_NAMED_LOOKUPS) {
+                std::wcout << prefix << "  subkey lookup: " << (nkSubkeys.size() - MAX_NAMED_LOOKUPS)
+                    << " more skipped (threshold=" << MAX_NAMED_LOOKUPS << ")" << std::endl;
+            }
+        }
+
+        {
+            size_t lookupCount = std::min(vkRecords.size(), MAX_NAMED_LOOKUPS);
+            for (size_t idx = 0; idx < lookupCount; ++idx) {
+                std::wstring name = vkRecords[idx]->getName();
+                try {
+                    auto looked = regKey.getValue(name);
+                }
+                catch (std::exception& ex) {
+                    std::wcout << prefix << "  value lookup \"" << name << "\": FAILED. exception ("
+                        << ex.what() << ")" << std::endl;
+                }
+            }
+            if (vkRecords.size() > MAX_NAMED_LOOKUPS) {
+                std::wcout << prefix << "  value lookup: " << (vkRecords.size() - MAX_NAMED_LOOKUPS)
+                    << " more skipped (threshold=" << MAX_NAMED_LOOKUPS << ")" << std::endl;
+            }
+        }
+
+        // --- Recurse into subkeys (paired low-level + high-level) ---
+        size_t count = std::min(nkSubkeys.size(), rkSubkeys.size());
+        for (size_t i = 0; i < count; ++i) {
+            std::wcout << prefix << "  key: " << nkSubkeys[i]->getName() << std::endl;
+            recurseAll(nkSubkeys[i].get(), *rkSubkeys[i], L"    " + prefix, depth + 1);
+        }
+
+        // If sizes differ, still print remaining NKRecord subkeys
+        for (size_t i = count; i < nkSubkeys.size(); ++i) {
+            std::wcout << prefix << "  key (nk only): " << nkSubkeys[i]->getName() << std::endl;
+        }
+        for (size_t i = count; i < rkSubkeys.size(); ++i) {
+            std::wcout << prefix << "  key (rk only): " << rkSubkeys[i]->getName() << std::endl;
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // Top-level hive processing
+    // -----------------------------------------------------------------------
+
     void processRegistryHive(RegistryHive& hive) {
+        // Reset stats for this hive
+        g_stats = HiveStats{};
+
         // Save and restore stream flags so repeated calls don't inherit
         // hex/fill state left behind by printVKRecord/dumpHexString.
         std::ios_base::fmtflags savedFlags = std::wcout.flags();
@@ -190,29 +571,83 @@ namespace Rejistry {
             std::wcout << "hive sync: " << (header->isSynchronized() ? "Yes" : "No") << std::endl;
 
             auto hbinList(header->getHBINs());
+            g_stats.hbinCount = static_cast<uint32_t>(hbinList.size());
             std::wcout << "number of hbins: " << hbinList.size() << std::endl;
             std::wcout << "last hbin offset: " << header->getLastHbinOffset() << std::endl;
 
+            // REGFHeader::getFirstHBIN()
+            try {
+                auto firstHbin = header->getFirstHBIN();
+                std::wcout << "first hbin relative offset first hbin: " << firstHbin->getRelativeOffsetFirstHBIN() << std::endl;
+                std::wcout << "first hbin relative offset next hbin: " << firstHbin->getRelativeOffsetNextHBIN() << std::endl;
+            }
+            catch (std::exception& ex) {
+                std::wcout << "getFirstHBIN exception: " << ex.what() << std::endl;
+            }
+
             int i = 0;
             for (auto& hbin : hbinList) {
-                std::wcout << "hbin " << i << ", relative offset first hbin: " << hbin->getRelativeOffsetFirstHBIN() << std::endl;
-                std::wcout << "hbin " << i << ", relative offset next hbin: " << hbin->getRelativeOffsetNextHBIN() << std::endl;
+                std::wcout << "hbin " << i
+                    << ", offset first: " << hbin->getRelativeOffsetFirstHBIN()
+                    << ", offset next: " << hbin->getRelativeOffsetNextHBIN()
+                    << std::endl;
 
                 int j = 0;
                 for (auto& cell : hbin->getCells()) {
-                    std::wcout << "hbin " << i << ", cell " << j << ", is allocated: " << (cell->isActive() ? "yes" : "no") << std::endl;
-                    std::wcout << "hbin " << i << ", cell " << j << ", length: " << cell->getLength() << std::endl;
+                    bool active = cell->isActive();
+
+                    g_stats.cellTotal++;
+                    if (active) {
+                        g_stats.cellAllocated++;
+                    }
+                    else {
+                        g_stats.cellUnallocated++;
+                    }
+
+                    try {
+                        std::string sig = cell->getDataSignature();
+                        std::wcout << "  cell " << j
+                            << ", allocated: " << (active ? "yes" : "no")
+                            << ", length: " << cell->getLength()
+                            << ", signature: " << sig.c_str()
+                            << ", data size: " << cell->getData().size()
+                            << std::endl;
+                        if (active) {
+                            if (sig == "nk" || sig == "vk" || sig == "lf" ||
+                                sig == "lh" || sig == "ri" || sig == "li" ||
+                                sig == "sk" || sig == "db") {
+                                g_stats.cellTypeCounts[sig]++;
+                            }
+                            else {
+                                g_stats.cellTypeCounts["(data)"]++;
+                            }
+                        }
+                    }
+                    catch (std::exception& ex) {
+                        std::wcout << "  cell " << j
+                            << ", allocated: " << (active ? "yes" : "no")
+                            << ", length: " << cell->getLength()
+                            << ", data: exception (" << ex.what() << ")"
+                            << std::endl;
+                    }
                     j++;
                 }
+
+
                 i++;
             }
 
-            auto root = header->getRootNKRecord();
-            recurseNKRecord(root.get(), L"");
+            // Single-pass tree traversal with both API layers
+            auto nkRoot = header->getRootNKRecord();
+            auto rkRoot = hive.getRoot();
+            recurseAll(nkRoot.get(), *rkRoot, L"");
         }
         catch (std::exception& ex) {
             std::wcout << "processRegistryHive exception: " << ex.what() << std::endl;
         }
+
+        // Print summary statistics
+        g_stats.print();
 
         std::wcout.flags(savedFlags);
         std::wcout.width(savedWidth);
@@ -228,6 +663,53 @@ namespace Rejistry {
         catch (std::exception& ex) {
             std::wcout << "processRegistryFile exception: " << ex.what() << std::endl;
         }
+    }
+}
+
+// -----------------------------------------------------------------------
+// SEH wrapper — must be in its own function because __try/__except cannot
+// coexist with C++ objects that have destructors in the same function.
+// -----------------------------------------------------------------------
+
+static const wchar_t* sehCodeToString(DWORD code) {
+    switch (code) {
+    case EXCEPTION_STACK_OVERFLOW:         return L"EXCEPTION_STACK_OVERFLOW";
+    case EXCEPTION_ACCESS_VIOLATION:       return L"EXCEPTION_ACCESS_VIOLATION";
+    case EXCEPTION_IN_PAGE_ERROR:          return L"EXCEPTION_IN_PAGE_ERROR";
+    case EXCEPTION_ILLEGAL_INSTRUCTION:    return L"EXCEPTION_ILLEGAL_INSTRUCTION";
+    case EXCEPTION_NONCONTINUABLE_EXCEPTION: return L"EXCEPTION_NONCONTINUABLE_EXCEPTION";
+    case EXCEPTION_INVALID_DISPOSITION:    return L"EXCEPTION_INVALID_DISPOSITION";
+    case EXCEPTION_ARRAY_BOUNDS_EXCEEDED:  return L"EXCEPTION_ARRAY_BOUNDS_EXCEEDED";
+    case EXCEPTION_FLT_DENORMAL_OPERAND:   return L"EXCEPTION_FLT_DENORMAL_OPERAND";
+    case EXCEPTION_FLT_DIVIDE_BY_ZERO:     return L"EXCEPTION_FLT_DIVIDE_BY_ZERO";
+    case EXCEPTION_FLT_OVERFLOW:           return L"EXCEPTION_FLT_OVERFLOW";
+    case EXCEPTION_FLT_UNDERFLOW:          return L"EXCEPTION_FLT_UNDERFLOW";
+    case EXCEPTION_INT_DIVIDE_BY_ZERO:     return L"EXCEPTION_INT_DIVIDE_BY_ZERO";
+    case EXCEPTION_INT_OVERFLOW:           return L"EXCEPTION_INT_OVERFLOW";
+    case EXCEPTION_PRIV_INSTRUCTION:       return L"EXCEPTION_PRIV_INSTRUCTION";
+    default:                               return L"UNKNOWN_SEH_EXCEPTION";
+    }
+}
+
+static int sehRunProcessRegistryFile(wchar_t* regFilePath) {
+    __try {
+        Rejistry::processRegistryFile(regFilePath);
+        return 0;
+    }
+    __except (EXCEPTION_EXECUTE_HANDLER) {
+        DWORD code = GetExceptionCode();
+        // If stack overflow, restore the guard page so we can keep running
+        // (printing the error message itself needs stack space).
+        if (code == EXCEPTION_STACK_OVERFLOW) {
+            _resetstkoflw();
+        }
+        std::wcout << std::endl
+            << L"FATAL: Structured Exception (SEH) 0x" << std::hex << code
+            << L" (" << sehCodeToString(code) << L")" << std::endl;
+        std::wcerr << std::endl
+            << L"FATAL: Structured Exception (SEH) 0x" << std::hex << code
+            << L" (" << sehCodeToString(code) << L")" << std::endl;
+        return 1;
     }
 }
 
@@ -252,5 +734,17 @@ int wmain(int argc, wchar_t *argv[], wchar_t *envp[])
         _setmode(_fileno(stdout), _O_U16TEXT);
     }
 
-    Rejistry::processRegistryFile(argv[1]);
+    auto start = std::chrono::high_resolution_clock::now();
+
+    int result = sehRunProcessRegistryFile(argv[1]);
+
+    auto end = std::chrono::high_resolution_clock::now();
+    auto totalSeconds = std::chrono::duration_cast<std::chrono::seconds>(end - start).count();
+    auto h = totalSeconds / 3600;
+    auto m = (totalSeconds % 3600) / 60;
+    auto s = totalSeconds % 60;
+    std::wcout << std::endl << L"=== Completed in " << std::dec
+        << h << L" h : " << m << L" m : " << s << L" s ===" << std::endl;
+
+    return result;
 }

--- a/rejistry++/src/Rejistry.cpp
+++ b/rejistry++/src/Rejistry.cpp
@@ -22,7 +22,6 @@
 #include <Windows.h>
 #include <io.h>
 #include <fcntl.h>
-#include <codecvt>
 
 #include "RegistryHiveFile.h"
 #include "RegistryHiveBuffer.h"
@@ -51,46 +50,34 @@ namespace Rejistry {
         uint8_t line[16];
         uint32_t lineIndex = 0;
 
-        std::cout << "0x";
-        std::cout << std::hex << std::setw(8) << std::setfill('0') << offset; 
+        std::wcout << L"0x";
+        std::wcout << std::hex << std::setw(8) << std::setfill(L'0') << offset;
 
         for (uint32_t i = offset; i < offset + length; ++i) {
             if (lineIndex == 16) {
-                std::wcout << " ";
+                std::wcout << L" ";
 
                 for (uint32_t j = 0; j < 16; j++) {
-                    if (line[j] >= ' ' && line[j] <= '~') {
-                        std::cout << line[j];
-                    }
-                    else {
-                        std::cout << ".";
-                    }
+                    std::wcout << (wchar_t)(line[j] >= ' ' && line[j] <= '~' ? line[j] : '.');
                 }
 
-                std::cout << std::endl;
+                std::wcout << std::endl;
                 for (uint16_t k = 0; k < linePadding; ++k) {
-                    std::cout << " ";
+                    std::wcout << L" ";
                 }
-                std::cout << "0x" << std::hex << std::uppercase << std::setw(8) << i; 
+                std::wcout << L"0x" << std::hex << std::uppercase << std::setw(8) << i;
                 lineIndex = 0;
             }
 
-            std::cout << " ";
-            uint8_t b = data[i];
-            std::wcout << std::hex << std::uppercase << std::setw(2) << std::setfill(L'0') << (int)b;
+            std::wcout << L" ";
+            std::wcout << std::hex << std::uppercase << std::setw(2) << std::setfill(L'0') << (int)data[i];
 
             line[lineIndex++] = data[i];
 
-            if (lineIndex == 16 && i == offset + length -1) {
-                std::cout << " ";
-
+            if (lineIndex == 16 && i == offset + length - 1) {
+                std::wcout << L" ";
                 for (uint32_t j = 0; j < 16; j++) {
-                    if (line[j] >= ' ' && line[j] <= '~') {
-                        std::cout << line[j];
-                    }
-                    else {
-                        std::cout << ".";
-                    }
+                    std::wcout << (wchar_t)(line[j] >= ' ' && line[j] <= '~' ? line[j] : '.');
                 }
             }
         }
@@ -98,16 +85,10 @@ namespace Rejistry {
         if (lineIndex != 16) {
             uint16_t count = ((16 - lineIndex) * 3) + 1;
             for (uint16_t i = 0; i < count; ++i) {
-                std::cout << " ";
+                std::wcout << L" ";
             }
-
             for (uint32_t i = 0; i < lineIndex; ++i) {
-                if (line[i] >= ' ' && line[i] <= '~') {
-                    std::cout << line[i];
-                }
-                else {
-                    std::cout << ".";
-                }
+                std::wcout << (wchar_t)(line[i] >= ' ' && line[i] <= '~' ? line[i] : '.');
             }
         }
     }
@@ -280,11 +261,23 @@ namespace Rejistry {
 int wmain(int argc, wchar_t *argv[], wchar_t *envp[])
 {
     if (argc < 2) {
-        std::wcout << "Usage: " << argv[0] << " <path to registry file>" << std::endl;
+        std::wcout << L"Usage: " << argv[0] << L" <path to registry file> [output file]" << std::endl;
         exit(1);
     }
 
-    std::wcout.imbue(std::locale(std::wcout.getloc(), new std::codecvt_utf8_utf16<wchar_t>()));
+    if (argc >= 3) {
+        // Redirect stdout to the output file at the OS level, then set UTF-8
+        // text mode. This is more reliable than imbuing with codecvt facets.
+        if (_wfreopen(argv[2], L"w", stdout) == nullptr) {
+            std::wcerr << L"Failed to open output file: " << argv[2] << std::endl;
+            exit(1);
+        }
+        _setmode(_fileno(stdout), _O_U8TEXT);
+    }
+    else {
+        // No output file — write UTF-16 directly to the console
+        _setmode(_fileno(stdout), _O_U16TEXT);
+    }
 
     Rejistry::processRegistryFile(argv[1]);
     Rejistry::processRegistryBuffer(argv[1]);

--- a/rejistry++/src/RejistryException.cpp
+++ b/rejistry++/src/RejistryException.cpp
@@ -70,10 +70,10 @@ namespace Rejistry {
 
     const char * RejistryException::what() const throw()
     {
-        std::string whatMsg = name();
+        m_what = name();
         if (m_msg.length())
-            whatMsg += ": " + m_msg;
-        return whatMsg.c_str();
+            m_what += ": " + m_msg;
+        return m_what.c_str();
     }
 
     REJISTRY_IMPLEMENT_EXCEPTION(RegistryParseException, RejistryException, "Error parsing registry")

--- a/rejistry++/src/RejistryException.h
+++ b/rejistry++/src/RejistryException.h
@@ -76,6 +76,7 @@ namespace Rejistry {
     private:
         std::string m_msg;
         int m_code;
+        mutable std::string m_what; ///< Cached result of what() to avoid returning a dangling pointer.
     };
 
     inline const std::string& RejistryException::message() const

--- a/rejistry++/src/SubkeyListRecord.cpp
+++ b/rejistry++/src/SubkeyListRecord.cpp
@@ -37,30 +37,14 @@ namespace Rejistry {
         return getWord(LIST_LENGTH_OFFSET);
     }
 
-    NKRecord * SubkeyListRecord::getSubkey(const std::wstring& name) const {
-        NKRecord::NKRecordPtr foundRecord = NULL;
-
-        NKRecord::NKRecordPtrList subKeys = getSubkeys();
-        NKRecord::NKRecordPtrList::iterator nkIter = subKeys.begin();
-        for (; nkIter != subKeys.end(); ++nkIter) {
-            if (_wcsicmp(name.c_str(), (*nkIter)->getName().c_str()) == 0) {
-                // Create a copy of the record to return as the records
-                // in the list will be deleted.
-                foundRecord = new NKRecord(*(*nkIter));
-                break;
+    NKRecord::NKRecordUniqPtr SubkeyListRecord::getSubkey(const std::wstring& name) const {
+        for (auto& nk : getSubkeys()) {
+            if (_wcsicmp(name.c_str(), nk->getName().c_str()) == 0) {
+                return std::move(nk);
             }
         }
 
-        // Free the list of records.
-        for (nkIter = subKeys.begin(); nkIter != subKeys.end(); ++nkIter) {
-            delete *nkIter;
-        }
-
-        if (foundRecord == NULL) {
-            throw NoSuchElementException("Failed to find subkey.");
-        }
-
-        return foundRecord;
+        throw NoSuchElementException("Failed to find subkey.");
     }
 
 };

--- a/rejistry++/src/SubkeyListRecord.h
+++ b/rejistry++/src/SubkeyListRecord.h
@@ -56,7 +56,7 @@ namespace Rejistry {
         /**
          * @returns The number of subkeys this list has.
          */
-        uint16_t getListLength() const;
+        virtual uint16_t getListLength() const;
 
         /**
          * @returns The list of subkeys.

--- a/rejistry++/src/SubkeyListRecord.h
+++ b/rejistry++/src/SubkeyListRecord.h
@@ -59,27 +59,24 @@ namespace Rejistry {
         uint16_t getListLength() const;
 
         /**
-         * @returns The list of subkeys. The caller is responsible for
-         * freeing the returned record list.
+         * @returns The list of subkeys.
          */
-        virtual std::vector<NKRecord*> getSubkeys() const = 0;
+        virtual std::vector<std::unique_ptr<NKRecord>> getSubkeys() const = 0;
 
         /**
          * Fetch the subkey with the given name from the subkey list.
          * @param name The name of the subkey to fetch.
-         * @returns The matching subkey record. The caller is responsible
-         * for freeing the returned record.
+         * @returns The matching subkey record.
          */
-        NKRecord * getSubkey(const std::wstring& name) const;
+        std::unique_ptr<NKRecord> getSubkey(const std::wstring& name) const;
 
     private:
         static const uint16_t LIST_LENGTH_OFFSET = 0x02;
 
     protected:
         SubkeyListRecord();
-        SubkeyListRecord(const SubkeyListRecord &);
-        SubkeyListRecord& operator=(const SubkeyListRecord &);
-
+        SubkeyListRecord(const SubkeyListRecord &) = delete;
+        SubkeyListRecord& operator=(const SubkeyListRecord &) = delete;
     };
 };
 

--- a/rejistry++/src/VKRecord.cpp
+++ b/rejistry++/src/VKRecord.cpp
@@ -101,15 +101,15 @@ namespace Rejistry {
 
     }
 
-    ValueData::ValueDataPtr VKRecord::getValue() const {
+    ValueData::ValueDataUniqPtr VKRecord::getValue() const {
         uint32_t length = getRawDataLength();
         uint32_t offset = getDataOffset();
 
-        if (length > LARGE_DATA_SIZE + DB_DATA_SIZE) {
+        if (length > (LARGE_DATA_SIZE + DB_DATA_SIZE)) {
             throw RegistryParseException("Value size too large.");
         }
 
-        std::unique_ptr< RegistryByteBuffer> data = NULL;
+        std::unique_ptr<RegistryByteBuffer> data = nullptr;
 
         switch (getValueType()) {
         case ValueData::VALTYPE_BIN:
@@ -128,14 +128,8 @@ namespace Rejistry {
             }
             else if (DB_DATA_SIZE < length && length < LARGE_DATA_SIZE) {
                 auto c = std::make_unique< Cell >(_buf, offset);
-                if (c.get() == NULL) {
-                    throw RegistryParseException("Failed to create Cell for Value data.");
-                }
                 try {
                     auto db = c->getDBRecord();
-                    if (db.get() == NULL) {
-                        throw RegistryParseException("Failed to create Cell for DBRecord.");
-                    }
                     data = std::make_unique<RegistryByteBuffer>(std::make_unique<ByteBuffer>(db->getData(length), length));
                 }
                 catch (RegistryParseException& ) {
@@ -144,9 +138,6 @@ namespace Rejistry {
             }
             else {
                 auto c = std::make_unique< Cell >(_buf, offset);
-                if (c.get() == NULL) {
-                    throw RegistryParseException("Failed to create Cell for Value data.");
-                }
                 data = std::make_unique<RegistryByteBuffer>(std::make_unique<ByteBuffer>(c->getData(), length));
             }
             break;
@@ -158,9 +149,6 @@ namespace Rejistry {
         case ValueData::VALTYPE_FILETIME:
             {
                 auto c = std::make_unique< Cell >(_buf, offset);
-                if (c.get() == NULL) {
-                    throw RegistryParseException("Failed to create Cell for Value data.");
-                }
                 data = std::make_unique<RegistryByteBuffer>(std::make_unique<ByteBuffer>(c->getData(), length));
             }
             break;
@@ -169,6 +157,6 @@ namespace Rejistry {
             data = std::make_unique<RegistryByteBuffer>(std::make_unique<ByteBuffer>(0));
         }
 
-        return new ValueData(std::move(data), getValueType());                                                            
+        return std::make_unique<ValueData>(std::move(data), getValueType());                                                            
     }
 };

--- a/rejistry++/src/VKRecord.cpp
+++ b/rejistry++/src/VKRecord.cpp
@@ -109,7 +109,7 @@ namespace Rejistry {
             throw RegistryParseException("Value size too large.");
         }
 
-        RegistryByteBuffer * data = NULL;
+        std::unique_ptr< RegistryByteBuffer> data = NULL;
 
         switch (getValueType()) {
         case ValueData::VALTYPE_BIN:
@@ -124,10 +124,10 @@ namespace Rejistry {
 
             if (length >= LARGE_DATA_SIZE) {
                 uint32_t bufSize = length - LARGE_DATA_SIZE;
-                data = new RegistryByteBuffer(new ByteBuffer(getData(DATA_OFFSET_OFFSET, bufSize), bufSize));
+                data = std::make_unique<RegistryByteBuffer>(std::make_unique<ByteBuffer>(getData(DATA_OFFSET_OFFSET, bufSize), bufSize));
             }
             else if (DB_DATA_SIZE < length && length < LARGE_DATA_SIZE) {
-                std::unique_ptr< Cell > c(new Cell(_buf, offset));
+                auto c = std::make_unique< Cell >(_buf, offset);
                 if (c.get() == NULL) {
                     throw RegistryParseException("Failed to create Cell for Value data.");
                 }
@@ -136,41 +136,39 @@ namespace Rejistry {
                     if (db.get() == NULL) {
                         throw RegistryParseException("Failed to create Cell for DBRecord.");
                     }
-                    data = new RegistryByteBuffer(new ByteBuffer(db->getData(length), length));
+                    data = std::make_unique<RegistryByteBuffer>(std::make_unique<ByteBuffer>(db->getData(length), length));
                 }
                 catch (RegistryParseException& ) {
-                    data = new RegistryByteBuffer(new ByteBuffer(c->getData(), length));
+                    data = std::make_unique<RegistryByteBuffer>(std::make_unique<ByteBuffer>(c->getData(), length));
                 }
             }
             else {
-                std::unique_ptr< Cell > c(new Cell(_buf, offset));
+                auto c = std::make_unique< Cell >(_buf, offset);
                 if (c.get() == NULL) {
                     throw RegistryParseException("Failed to create Cell for Value data.");
                 }
-                ByteBuffer * byteBuffer = new ByteBuffer(c->getData(), length);
-                data = new RegistryByteBuffer(byteBuffer);
+                data = std::make_unique<RegistryByteBuffer>(std::make_unique<ByteBuffer>(c->getData(), length));
             }
             break;
         case ValueData::VALTYPE_DWORD:
         case ValueData::VALTYPE_BIG_ENDIAN:
-            data = new RegistryByteBuffer(new ByteBuffer(getData(DATA_OFFSET_OFFSET, 0x4), 0x4));
+            data = std::make_unique<RegistryByteBuffer>(std::make_unique<ByteBuffer>(getData(DATA_OFFSET_OFFSET, 0x4), 0x4));
             break;
         case ValueData::VALTYPE_QWORD:
         case ValueData::VALTYPE_FILETIME:
             {
-                std::unique_ptr< Cell > c(new Cell(_buf, offset));
+                auto c = std::make_unique< Cell >(_buf, offset);
                 if (c.get() == NULL) {
                     throw RegistryParseException("Failed to create Cell for Value data.");
                 }
-                ByteBuffer * byteBuffer = new ByteBuffer(c->getData(), length);
-                data = new RegistryByteBuffer(byteBuffer);
+                data = std::make_unique<RegistryByteBuffer>(std::make_unique<ByteBuffer>(c->getData(), length));
             }
             break;
         default:
             // Unknown registry type. Create an empty buffer.
-            data = new RegistryByteBuffer(new ByteBuffer(0));
+            data = std::make_unique<RegistryByteBuffer>(std::make_unique<ByteBuffer>(0));
         }
 
-        return new ValueData(data, getValueType());                                                            
+        return new ValueData(std::move(data), getValueType());                                                            
     }
 };

--- a/rejistry++/src/VKRecord.cpp
+++ b/rejistry++/src/VKRecord.cpp
@@ -26,6 +26,7 @@
  *
  */
 #include <memory>
+#include <algorithm>
 
 // Local includes
 #include "VKRecord.h"
@@ -148,8 +149,20 @@ namespace Rejistry {
         case ValueData::VALTYPE_QWORD:
         case ValueData::VALTYPE_FILETIME:
             {
-                auto c = std::make_unique< Cell >(_buf, offset);
-                data = std::make_unique<RegistryByteBuffer>(std::make_unique<ByteBuffer>(c->getData(), length));
+                uint32_t dataLen = getDataLength();
+                if (length >= LARGE_DATA_SIZE) {
+                    // Data is stored inline in the VK record (≤4 bytes).
+                    // Malformed QWORD/FILETIME — getAsNumber() will return 0.
+                    data = std::make_unique<RegistryByteBuffer>(
+                        std::make_unique<ByteBuffer>(getData(DATA_OFFSET_OFFSET, dataLen), dataLen));
+                }
+                else {
+                    auto c = std::make_unique<Cell>(_buf, offset);
+                    ByteBuffer::ByteArray cellData = c->getData();
+                    uint32_t safeLength = std::min(length, static_cast<uint32_t>(cellData.size()));
+                    data = std::make_unique<RegistryByteBuffer>(
+                        std::make_unique<ByteBuffer>(cellData, safeLength));
+                }
             }
             break;
         default:

--- a/rejistry++/src/VKRecord.h
+++ b/rejistry++/src/VKRecord.h
@@ -47,6 +47,7 @@ namespace Rejistry {
 
         typedef VKRecord * VKRecordPtr;
         typedef std::vector< VKRecordPtr > VKRecordPtrList;
+        typedef std::vector< std::unique_ptr<VKRecord> > VKRecordUniqPtrList;
 
         /**
             The AutoNKRecordPtrList class should be used by clients to hold lists of

--- a/rejistry++/src/VKRecord.h
+++ b/rejistry++/src/VKRecord.h
@@ -45,43 +45,8 @@ namespace Rejistry {
     public:
         static const std::wstring DEFAULT_VALUE_NAME;
 
-        typedef VKRecord * VKRecordPtr;
-        typedef std::vector< VKRecordPtr > VKRecordPtrList;
-        typedef std::vector< std::unique_ptr<VKRecord> > VKRecordUniqPtrList;
-
-        /**
-            The AutoNKRecordPtrList class should be used by clients to hold lists of
-            VKRecord pointers returned by methods like ValueListRecord::getValues()
-            so that the record objects will be automatically freed. Example:
-            @code
-            AutoVKRecordPtrList valueList(nkRecord->getValueList()->getValues());
-            for (VKRecord::VKRecordPtrList::iterator i = valueList.begin(); i != valueList.end(); ++i)
-            { ... //do stuff }
-            // Don't worry about delete'ing each record object--valueList will take care of
-            // that when it goes out of scope.
-            @endcode
-        */
-        class AutoVKRecordPtrList
-        {
-        public:
-
-            AutoVKRecordPtrList(VKRecordPtrList recordList) : _recordList(recordList) {}
-            ~AutoVKRecordPtrList()
-            {
-                for (VKRecordPtrList::iterator it = _recordList.begin(); it != _recordList.end(); ++it)
-                {
-                    delete *it;
-                }
-            }
-            VKRecordPtrList::iterator begin() { return _recordList.begin(); }
-            VKRecordPtrList::iterator end()   { return _recordList.end(); }
-            VKRecordPtrList::size_type size() { return _recordList.size(); }
-        private:
-            AutoVKRecordPtrList(const AutoVKRecordPtrList&);
-            AutoVKRecordPtrList& operator=(const AutoVKRecordPtrList&);
-
-            VKRecordPtrList _recordList;
-        };
+        typedef std::unique_ptr<VKRecord> VKRecordUniqPtr;
+        typedef std::vector< VKRecordUniqPtr > VKRecordUniqPtrList;
 
         VKRecord(RegistryByteBuffer * buf, uint32_t offset);
         VKRecord(const VKRecord &);
@@ -135,7 +100,7 @@ namespace Rejistry {
          * responsible for freeing the data.
          * @throws RegistryParseException
          */
-        ValueData::ValueDataPtr getValue() const;
+        ValueData::ValueDataUniqPtr getValue() const;
 
     private:
         static const std::string MAGIC;

--- a/rejistry++/src/ValueData.cpp
+++ b/rejistry++/src/ValueData.cpp
@@ -110,6 +110,4 @@ namespace Rejistry {
             return L"Unrecognized type";
         }
     }
-
-
 };

--- a/rejistry++/src/ValueData.h
+++ b/rejistry++/src/ValueData.h
@@ -43,7 +43,7 @@ namespace Rejistry {
      */
     class ValueData {
     public:
-        typedef ValueData* ValueDataPtr;
+        typedef std::unique_ptr<ValueData> ValueDataUniqPtr;
 
         enum VALUE_TYPES {
             VALTYPE_NONE = 0,

--- a/rejistry++/src/ValueData.h
+++ b/rejistry++/src/ValueData.h
@@ -43,7 +43,7 @@ namespace Rejistry {
      */
     class ValueData {
     public:
-        typedef ValueData * ValueDataPtr;
+        typedef ValueData* ValueDataPtr;
 
         enum VALUE_TYPES {
             VALTYPE_NONE = 0,
@@ -65,14 +65,12 @@ namespace Rejistry {
         /// Map the value type enum to a string.
         static std::wstring getValueType(ValueData::VALUE_TYPES type);
 
-        ValueData(RegistryByteBuffer * buf, const VALUE_TYPES type) {
-            _buf = buf;
+        ValueData(std::unique_ptr<RegistryByteBuffer> buf, const VALUE_TYPES type) {
+            _buf = std::move(buf);
             _type = type;
         }
         
         ~ValueData() {
-            if (_buf)
-                delete _buf;
         }
 
         VALUE_TYPES getValueType() const { return _type; };
@@ -113,7 +111,7 @@ namespace Rejistry {
         ValueData(const ValueData &);
         ValueData& operator=(const ValueData &);
 
-        RegistryByteBuffer * _buf;
+        std::unique_ptr<RegistryByteBuffer> _buf;
         VALUE_TYPES _type;
     };
 };

--- a/rejistry++/src/ValueListRecord.cpp
+++ b/rejistry++/src/ValueListRecord.cpp
@@ -38,13 +38,14 @@ namespace Rejistry {
     ValueListRecord::ValueListRecord(RegistryByteBuffer * buf, uint32_t offset, uint32_t numValues) 
         : Record(buf, offset), _numValues(numValues) {}
 
-    VKRecord::VKRecordPtrList ValueListRecord::getValues() const {
-        VKRecord::VKRecordPtrList valueList;
+    VKRecord::VKRecordUniqPtrList ValueListRecord::getValues() const {
+        VKRecord::VKRecordUniqPtrList valueList;
 
         for (uint32_t index = 0; index < _numValues; ++index) {
             uint32_t offset = getDWord(VALUE_LIST_OFFSET + (0x4 * index));
             offset += REGFHeader::FIRST_HBIN_OFFSET;
-            std::unique_ptr< Cell > c(new Cell(_buf, offset));
+
+            auto c = std::make_unique< Cell >(_buf, offset);
             if (c.get() == NULL) {
                 throw RegistryParseException("Failed to create Cell for value record.");
             }
@@ -58,24 +59,16 @@ namespace Rejistry {
     VKRecord::VKRecordPtr ValueListRecord::getValue(const std::wstring& name) const {
         VKRecord::VKRecordPtr foundRecord = NULL;
 
-        VKRecord::VKRecordPtrList recordList = getValues();
-        VKRecord::VKRecordPtrList::iterator it = recordList.begin();
-
-        for (; it != recordList.end(); ++it) {
+        for (const auto& valueRecord : getValues()) {
             // If we have a name match or we are searching for the "default" entry
             // (which matches a record with no name) we are done.
-            if ((!(*it)->hasName() && name == VKRecord::DEFAULT_VALUE_NAME) ||
-                (_wcsicmp(name.c_str(), (*it)->getName().c_str()) == 0)) {
+            if ((!valueRecord->hasName() && name == VKRecord::DEFAULT_VALUE_NAME) ||
+                (_wcsicmp(name.c_str(), valueRecord->getName().c_str()) == 0)) {
                 // Create a copy of the record to return as the records
                 // in the list will be deleted.
-                foundRecord = new VKRecord(*(*it));
+                foundRecord = new VKRecord(*valueRecord);
                 break;
             }
-        }
-
-        // Free the list of records.
-        for (it = recordList.begin(); it != recordList.end(); ++it) {
-            delete *it;
         }
 
         if (foundRecord == NULL) {

--- a/rejistry++/src/ValueListRecord.cpp
+++ b/rejistry++/src/ValueListRecord.cpp
@@ -46,35 +46,20 @@ namespace Rejistry {
             offset += REGFHeader::FIRST_HBIN_OFFSET;
 
             auto c = std::make_unique< Cell >(_buf, offset);
-            if (c.get() == NULL) {
-                throw RegistryParseException("Failed to create Cell for value record.");
-            }
-
             valueList.push_back(c->getVKRecord());
         }
 
         return valueList;
     }
 
-    VKRecord::VKRecordPtr ValueListRecord::getValue(const std::wstring& name) const {
-        VKRecord::VKRecordPtr foundRecord = NULL;
-
-        for (const auto& valueRecord : getValues()) {
-            // If we have a name match or we are searching for the "default" entry
-            // (which matches a record with no name) we are done.
+    VKRecord::VKRecordUniqPtr ValueListRecord::getValue(const std::wstring& name) const {
+        for (auto& valueRecord : getValues()) {
             if ((!valueRecord->hasName() && name == VKRecord::DEFAULT_VALUE_NAME) ||
                 (_wcsicmp(name.c_str(), valueRecord->getName().c_str()) == 0)) {
-                // Create a copy of the record to return as the records
-                // in the list will be deleted.
-                foundRecord = new VKRecord(*valueRecord);
-                break;
+                return std::move(valueRecord);
             }
         }
 
-        if (foundRecord == NULL) {
-            throw NoSuchElementException("Failed to find value.");
-        }
-
-        return foundRecord;
+        throw NoSuchElementException("Failed to find value.");
     }
 };

--- a/rejistry++/src/ValueListRecord.h
+++ b/rejistry++/src/ValueListRecord.h
@@ -52,7 +52,7 @@ namespace Rejistry {
          * @returns The list of value records. The caller is responsible
          * for freeing these records.
          */
-        virtual VKRecord::VKRecordPtrList getValues() const;
+        virtual VKRecord::VKRecordUniqPtrList getValues() const;
 
         /**
          * Fetch the value with the given name from the value list.

--- a/rejistry++/src/ValueListRecord.h
+++ b/rejistry++/src/ValueListRecord.h
@@ -49,18 +49,16 @@ namespace Rejistry {
         virtual ~ValueListRecord() {}
     
         /**
-         * @returns The list of value records. The caller is responsible
-         * for freeing these records.
+         * @returns The list of value records.
          */
-        virtual VKRecord::VKRecordUniqPtrList getValues() const;
+        VKRecord::VKRecordUniqPtrList getValues() const;
 
         /**
          * Fetch the value with the given name from the value list.
          * @param name The name of the value to fetch.
-         * @returns The matching value record. The caller is responsible
-         * for freeing this record.
+         * @returns The matching value record.
          */
-        VKRecord::VKRecordPtr getValue(const std::wstring& name) const;
+        VKRecord::VKRecordUniqPtr getValue(const std::wstring& name) const;
 
         /**
         * @returns The ValueListRecord size
@@ -74,8 +72,8 @@ namespace Rejistry {
 
     protected:
         ValueListRecord() {};
-        ValueListRecord(const ValueListRecord &);
-        ValueListRecord& operator=(const ValueListRecord &);
+        ValueListRecord(const ValueListRecord &) = delete;
+        ValueListRecord& operator=(const ValueListRecord &) = delete;
 
     };
 };

--- a/tools/logicalimager/RegKey.cpp
+++ b/tools/logicalimager/RegKey.cpp
@@ -52,8 +52,8 @@ int RegKey::initialize(const Rejistry::RegistryKey *regKey) {
     // TODO - replace the following 2 lines when these methods are available in PR #1665
     // m_numSubkeys = regKey->getSubkeyListSize();
     // m_numValues = regKey->getValueListSize();
-    m_numSubkeys = regKey->getSubkeyList().size();
-    m_numValues = regKey->getValueList().size();
+    m_numSubkeys = regKey->getSubkeyListSize();
+    m_numValues = regKey->getValueListSize();
     uint64_t timestamp = regKey->getTimestamp();
     m_modifyTime.dwLowDateTime = (DWORD)(timestamp & 0xFFFFFFFF);
     m_modifyTime.dwHighDateTime = (DWORD)(timestamp >> 32);

--- a/tools/logicalimager/RegParser.cpp
+++ b/tools/logicalimager/RegParser.cpp
@@ -19,7 +19,7 @@ RegParser::RegParser(const RegHiveType::Enum aHiveType)
 
 RegParser::RegParser(const std::wstring &filePath) {
     m_registryHive = new Rejistry::RegistryHiveFile(filePath);
-    m_rootKey = m_registryHive->getRoot();
+    m_rootKey = m_registryHive->getRoot().release();
 }
 
 RegParser::~RegParser() {
@@ -81,7 +81,7 @@ int RegParser::loadHive(TSK_FS_FILE *aHiveFile, RegHiveType::Enum aHiveType) {
         free(registryBuffer);
         return -1;
     }
-    m_rootKey = m_registryHive->getRoot();
+    m_rootKey = m_registryHive->getRoot().release();
 
     free(registryBuffer);
     return 0;
@@ -116,10 +116,9 @@ int RegParser::getRootKey(RegKey &aKey) {
  *      -2 if there was an error getting the key.
  */
 int RegParser::getKey(const std::wstring &keyName, RegKey &aKey) {
-    const Rejistry::RegistryKey *key = NULL;
-
     try {
-        key = findKey(keyName);
+        std::unique_ptr<Rejistry::RegistryKey const> key(findKey(keyName));
+        aKey.initialize(key.get());
     }
     catch (Rejistry::NoSuchElementException&) {
         return -1;
@@ -131,11 +130,6 @@ int RegParser::getKey(const std::wstring &keyName, RegKey &aKey) {
         return -2;
     }
 
-    aKey.initialize(key);
-
-    if (key != NULL) {
-        delete key;
-    }
     return 0;
 }
 
@@ -154,18 +148,13 @@ int RegParser::getKey(const std::wstring &keyName, RegKey &aKey) {
  */
 int RegParser::getSubKeys(const std::wstring &keyName, std::vector<std::wstring> &subKeyNamesList) {
     try {
-        std::auto_ptr<Rejistry::RegistryKey const> key(findKey(keyName));
+        std::unique_ptr<Rejistry::RegistryKey const> key(findKey(keyName));
 
-        Rejistry::RegistryKey::RegistryKeyPtrList subkeys = key->getSubkeyList();
+        auto subkeys = key->getSubkeyList();
         subKeyNamesList.reserve(subkeys.size());
-        Rejistry::RegistryKey::RegistryKeyPtrList::iterator subKeyIter = subkeys.begin();
 
-        for (; subKeyIter != subkeys.end(); ++subKeyIter) {
-            subKeyNamesList.push_back((*subKeyIter)->getName());
-        }
-
-        for (subKeyIter = subkeys.begin(); subKeyIter != subkeys.end(); ++subKeyIter) {
-            delete *subKeyIter;
+        for (auto& subkey : subkeys) {
+            subKeyNamesList.push_back(subkey->getName());
         }
     }
     catch (Rejistry::NoSuchElementException&) {
@@ -195,20 +184,15 @@ int RegParser::getSubKeys(const std::wstring &keyName, std::vector<std::wstring>
  */
 int RegParser::getSubKeys(const std::wstring &keyName, std::vector<RegKey*> &subKeysList) {
     try {
-        std::auto_ptr<Rejistry::RegistryKey const> key(findKey(keyName));
+        std::unique_ptr<Rejistry::RegistryKey const> key(findKey(keyName));
 
-        Rejistry::RegistryKey::RegistryKeyPtrList subkeys = key->getSubkeyList();
+        auto subkeys = key->getSubkeyList();
         subKeysList.reserve(subkeys.size());
-        Rejistry::RegistryKey::RegistryKeyPtrList::iterator subKeyIter = subkeys.begin();
 
-        for (; subKeyIter != subkeys.end(); ++subKeyIter) {
-            RegKey * key = new RegKey((*subKeyIter)->getName());
-            key->initialize(*subKeyIter);
-            subKeysList.push_back(key);
-        }
-
-        for (subKeyIter = subkeys.begin(); subKeyIter != subkeys.end(); ++subKeyIter) {
-            delete *subKeyIter;
+        for (auto& subkey : subkeys) {
+            RegKey * rk = new RegKey(subkey->getName());
+            rk->initialize(subkey.get());
+            subKeysList.push_back(rk);
         }
     }
     catch (Rejistry::NoSuchElementException&) {
@@ -240,10 +224,9 @@ int RegParser::getSubKeys(const std::wstring &keyName, std::vector<RegKey*> &sub
  */
 int RegParser::getValue(const std::wstring &keyName, const std::wstring &valName, RegVal &val) {
     try {
-        std::auto_ptr<Rejistry::RegistryKey const> key(findKey(keyName));
-        Rejistry::RegistryValue *value = key->getValue(valName);
-        val.initialize(value);
-        delete value;
+        std::unique_ptr<Rejistry::RegistryKey const> key(findKey(keyName));
+        auto value = key->getValue(valName);
+        val.initialize(value.get());
     }
     catch (Rejistry::NoSuchElementException&) {
         return -1;
@@ -281,10 +264,9 @@ int RegParser::getValue(const RegKey *startKey, const std::wstring &subpathName,
     }
 
     try {
-        std::auto_ptr<Rejistry::RegistryKey const> key(findKey(subpathName, startKey->getRegistryKey()));
-        Rejistry::RegistryValue *value = key->getValue(valName);
-        val.initialize(value);
-        delete value;
+        std::unique_ptr<Rejistry::RegistryKey const> key(findKey(subpathName, startKey->getRegistryKey()));
+        auto value = key->getValue(valName);
+        val.initialize(value.get());
     }
     catch (Rejistry::NoSuchElementException&) {
         return -1;
@@ -313,18 +295,13 @@ int RegParser::getValue(const RegKey *startKey, const std::wstring &subpathName,
 */
 int RegParser::getValues(const std::wstring &keyName, std::vector<RegVal *> &valList) {
     try {
-        std::auto_ptr<Rejistry::RegistryKey const> key(findKey(keyName));
+        std::unique_ptr<Rejistry::RegistryKey const> key(findKey(keyName));
 
-        Rejistry::RegistryValue::RegistryValuePtrList values = key->getValueList();
+        auto values = key->getValueList();
         valList.reserve(values.size());
-        Rejistry::RegistryValue::RegistryValuePtrList::iterator valueIter = values.begin();
 
-        for (; valueIter != values.end(); ++valueIter) {
-            valList.push_back(new RegVal((*valueIter)));
-        }
-
-        for (valueIter = values.begin(); valueIter != values.end(); ++valueIter) {
-            delete *valueIter;
+        for (auto& value : values) {
+            valList.push_back(new RegVal(value.get()));
         }
     }
     catch (Rejistry::NoSuchElementException&) {
@@ -359,18 +336,13 @@ int RegParser::getValues(const RegKey *startKey, const std::wstring &subpathName
     }
 
     try {
-        std::auto_ptr<Rejistry::RegistryKey const> key(findKey(subpathName, startKey->getRegistryKey()));
+        std::unique_ptr<Rejistry::RegistryKey const> key(findKey(subpathName, startKey->getRegistryKey()));
 
-        Rejistry::RegistryValue::RegistryValuePtrList values = key->getValueList();
+        auto values = key->getValueList();
         valList.reserve(values.size());
-        Rejistry::RegistryValue::RegistryValuePtrList::iterator valueIter = values.begin();
 
-        for (; valueIter != values.end(); ++valueIter) {
-            valList.push_back(new RegVal((*valueIter)));
-        }
-
-        for (valueIter = values.begin(); valueIter != values.end(); ++valueIter) {
-            delete *valueIter;
+        for (auto& value : values) {
+            valList.push_back(new RegVal(value.get()));
         }
     }
     catch (Rejistry::NoSuchElementException&) {
@@ -405,16 +377,13 @@ const Rejistry::RegistryKey *RegParser::findKey(const std::wstring &keyName, con
     std::vector<std::wstring> keyElements = splitKeyName(keyName);
     std::vector<std::wstring>::iterator keyIter = keyElements.begin();
     const Rejistry::RegistryKey *currentKey = startingKey == NULL ? m_rootKey : startingKey;
+    std::unique_ptr<Rejistry::RegistryKey> ownedKey;
 
     // Navigate our way down the tree looking to locate the desired key.
     for (; keyIter != keyElements.end(); ++keyIter) {
         try {
-            Rejistry::RegistryKey *nextKey = currentKey->getSubkey((*keyIter));
-            if (currentKey != m_rootKey && currentKey != startingKey) {
-                // Free the key we just searched (as long as its not the root or the starting key)
-                delete currentKey;
-            }
-            currentKey = nextKey;
+            ownedKey = currentKey->getSubkey((*keyIter));
+            currentKey = ownedKey.get();
         }
         catch (Rejistry::NoSuchElementException&) {
             // If we fail on the root element, we will continue and
@@ -426,11 +395,11 @@ const Rejistry::RegistryKey *RegParser::findKey(const std::wstring &keyName, con
         }
     }
 
-    if (currentKey == startingKey) {
-        return new Rejistry::RegistryKey(*currentKey);
+    if (ownedKey) {
+        return ownedKey.release();
     }
     else {
-        return currentKey;
+        return new Rejistry::RegistryKey(*currentKey);
     }
 }
 

--- a/tools/logicalimager/RegVal.cpp
+++ b/tools/logicalimager/RegVal.cpp
@@ -135,7 +135,7 @@ int RegVal::initialize(const Rejistry::RegistryValue *value) {
         m_valLen = value->getValueLength();
         m_registryValue = new Rejistry::RegistryValue(*value);
 
-        Rejistry::ValueData * valueData = value->getValue();
+        auto valueData = value->getValue();
 
         switch (m_valType) {
         case REG_DWORD:
@@ -164,7 +164,6 @@ int RegVal::initialize(const Rejistry::RegistryValue *value) {
             // This shouldn't happen because we check the range above.
             break;
         }
-        delete valueData;
     }
     catch (Rejistry::RegistryParseException& e)
     {


### PR DESCRIPTION
- Replace raw pointer ownership with unique_ptr throughout the library: RegistryByteBuffer, ValueData, RegistryKey, RegistryValue, RegistryHiveFile, RegistryHiveBuffer, Cell, HBIN, REGFHeader, NKRecord, VKRecord, ValueListRecord
- Remove AutoCellPtrList and AutoHBINPtrList RAII wrappers now that unique_ptr handles lifetime automatically
- Add virtual destructor to BinaryBlock to prevent UB when deleting through base class pointer
- Fix integer overflow in ByteBuffer::read() bounds check via uint64_t cast
- Fix dangling pointer in RejistryException::what() by caching result in mutable member
- Fix RegistryHiveFile::getErrorMessage() to handle FormatMessageA failure
- Fix REGFHeader::getHBINs() to std::move unique_ptr into vector
- Refactor Rejistry test program to exercise both RegistryHiveFile and RegistryHiveBuffer through shared processRegistryHive() function