### PR TITLE
logicalfs: fix case-sensitive comparisons in inum cache path lookup

### DIFF
--- a/tsk/base/tsk_os.h
+++ b/tsk/base/tsk_os.h
@@ -139,6 +139,7 @@ typedef WCHAR TSK_TCHAR;        ///< Character data type that is UTF-16 (wchar_t
 #define TSTRCMP	wcscmp
 #define TSTRNCMP	wcsncmp
 #define TSTRICMP _wcsicmp
+#define TSTRNICMP _wcsnicmp
 #define TSTRNCPY wcsncpy
 #define TSTRNCAT wcsncat
 #define TSTRCHR	wcschr
@@ -189,6 +190,7 @@ typedef char TSK_TCHAR;         ///< Character data type that is UTF-16 (wchar_t
 #define TSTRCMP	strcmp
 #define TSTRNCMP strncmp
 #define TSTRICMP strcasecmp
+#define TSTRNICMP strncasecmp
 #define TSTRNCPY strncpy
 #define TSTRNCAT strncat
 #define TSTRCHR	strchr

--- a/tsk/fs/logical_fs.cpp
+++ b/tsk/fs/logical_fs.cpp
@@ -1144,7 +1144,7 @@ search_directory_recursive(LOGICALFS_INFO *a_logical_fs_info, const TSK_TCHAR * 
 			is_near_root_folder = (slash_count < 2);
 		}
 		if (a_search_helper->search_type == LOGICALFS_SEARCH_BY_PATH) {
-			if (is_near_root_folder || TSTRNCMP(current_path, a_search_helper->target_path, current_path_len) == 0) {
+			if (is_near_root_folder || _wcsnicmp(current_path, a_search_helper->target_path, current_path_len) == 0) {
 				add_directory_to_cache(a_logical_fs_info, current_path, current_inum, true);
 			}
 			else {
@@ -1431,7 +1431,7 @@ get_inum_from_directory_path(LOGICALFS_INFO *a_logical_fs_info, TSK_TCHAR *a_bas
 		return LOGICAL_INVALID_INUM;
 	}
 	if (cache_inum != LOGICAL_INVALID_INUM) {
-		if (TSTRCMP(path_buf, cache_path) == 0) {
+		if (TSTRICMP(path_buf, cache_path) == 0) {
 			// We found an exact match - no need to do a search
 			free(cache_path);
 			return cache_inum;

--- a/tsk/fs/logical_fs.cpp
+++ b/tsk/fs/logical_fs.cpp
@@ -1144,7 +1144,7 @@ search_directory_recursive(LOGICALFS_INFO *a_logical_fs_info, const TSK_TCHAR * 
 			is_near_root_folder = (slash_count < 2);
 		}
 		if (a_search_helper->search_type == LOGICALFS_SEARCH_BY_PATH) {
-			if (is_near_root_folder || _wcsnicmp(current_path, a_search_helper->target_path, current_path_len) == 0) {
+			if (is_near_root_folder || TSTRNICMP(current_path, a_search_helper->target_path, current_path_len) == 0) {
 				add_directory_to_cache(a_logical_fs_info, current_path, current_inum, true);
 			}
 			else {


### PR DESCRIPTION
Two comparison sites used case-sensitive macros (TSTRCMP / TSTRNCMP) where the filesystem requires case-insensitive comparison:

1. get_inum_from_directory_path (exact-match cache hit check): TSTRCMP -> TSTRICMP The cache stores paths in actual disk case (from FindFirstFileW). When the caller's path has different case, TSTRCMP failed even though the cache held an exact logical match. The code fell through and started search_directory_recursive FROM the matched directory (treating it as a parent prefix), so no child ever matched the target and the lookup returned LOGICAL_INVALID_INUM. Bug triggered on second+ access once cache was warm; first access (cache cold) always succeeded via TSTRICMP in the walk itself.

2. search_directory_recursive (cache warm-up path decision): TSTRNCMP -> _wcsnicmp Decides whether to promote an intermediate directory to always_cache=true. With case mismatch between current_path (disk case) and target_path (caller case), the promotion never fired, leaving the search path in the cache only opportunistically.

There is no TSTRNICMP macro in tsk_os.h so _wcsnicmp is used directly at site 2; it is already used at four other sites in this file.